### PR TITLE
Fix for retrieving message data

### DIFF
--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergData.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergData.scala
@@ -47,7 +47,7 @@ private[bloomberg] object BloombergData {
     * @return
     */
   def apply(ticker: String, element: Element): BloombergData = {
-    val fields = (0 until element.numValues())
+    val fields = (0 until element.numElements())
       .map(element.getElement)
       .filter(f => !f.isNull)
       .foldLeft {

--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergFieldValueFn.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergFieldValueFn.scala
@@ -84,7 +84,7 @@ private[bloomberg] object BloombergFieldValueFn {
       0
     }
     val offset = ZoneOffset.ofTotalSeconds(offsetSeconds)
-    OffsetTime.of(dt.hour(), dt.minute(), dt.second(), dt.nanosecond(), offset).toString
+    OffsetTime.of(dt.hour()-1, dt.minute(), dt.second(), dt.nanosecond(), offset).toString
   }
 
   def localDate(dt: Datetime): String = {


### PR DESCRIPTION
Fix for conversion of Bloomberg Datetime to OffsetTime (Bloomberg datetime objects represent values from 1-24 as opposed to java 0-23)
Fixed element traversal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/280)
<!-- Reviewable:end -->
