### PR TITLE
fix(kafka-connect-jms): ActiveMQ libs are only required at test-time

### DIFF
--- a/kafka-connect-jms/build.gradle
+++ b/kafka-connect-jms/build.gradle
@@ -23,8 +23,8 @@ project(":kafka-connect-jms") {
     }
 
     dependencies {
-        compile("org.apache.activemq:activemq-core:5.7.0")
         compile("javax.jms:javax.jms-api:$jmsVersion")
+        testCompile("org.apache.activemq:activemq-core:5.7.0")
         testCompile("org.json4s:json4s-native_$scalaMajorVersion:$json4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-core_$scalaMajorVersion:$avro4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-macros_$scalaMajorVersion:$avro4sVersion")


### PR DESCRIPTION
Change scope of dependency from 'compile' to 'testCompile'

Fixes #326