### PR TITLE
Added support for filtering files via RegEx

### DIFF
--- a/conf/ftp-source.properties
+++ b/conf/ftp-source.properties
@@ -28,6 +28,9 @@ connect.ftp.refresh=PT1M
 #ignore files older than 14 days.
 connect.ftp.file.maxage=P14D
 
+#Regular expression to use when selecting files for processing ignoring file which do not match
+connect.ftp.filter=.*
+
 #monitor /forecasts/weather/ and /logs/ for appends to files.
 #any updates go to the topics `weather` and `error-logs` respectively.
 connect.ftp.monitor.tail=/forecasts/weather/:weather,/logs/:error-logs

--- a/kafka-connect-ftp/src/main/scala/com/datamountaineer/streamreactor/connect/ftp/source/FtpSourceConfig.scala
+++ b/kafka-connect-ftp/src/main/scala/com/datamountaineer/streamreactor/connect/ftp/source/FtpSourceConfig.scala
@@ -54,6 +54,7 @@ object FtpSourceConfig {
   val SourceRecordConverter = "connect.ftp.sourcerecordconverter"
   val FtpMaxPollRecords = "connect.ftp.max.poll.records"
   val protocol = "connect.ftp.protocol"
+  val fileFilter = "connect.ftp.filter"
 
   val definition: ConfigDef = new ConfigDef()
     .define(Address, Type.STRING, Importance.HIGH, "ftp address[:port]")
@@ -69,6 +70,7 @@ object FtpSourceConfig {
     .define(SourceRecordConverter, Type.CLASS, "com.datamountaineer.streamreactor.connect.ftp.source.NopSourceRecordConverter", Importance.HIGH, s"TODO")
     .define(FtpMaxPollRecords, Type.INT, 10000, Importance.LOW, "Max number of records returned per poll")
     .define(protocol, Type.STRING, "ftp", Importance.LOW, "FTPS or FTP protocol")
+    .define(fileFilter, Type.STRING, ".*", Importance.LOW, "Regular expression to use when selecting files for processing ignoring file which do not match")
 }
 
 // abstracts the properties away a bit

--- a/kafka-connect-ftp/src/main/scala/com/datamountaineer/streamreactor/connect/ftp/source/FtpSourceTask.scala
+++ b/kafka-connect-ftp/src/main/scala/com/datamountaineer/streamreactor/connect/ftp/source/FtpSourceTask.scala
@@ -58,7 +58,8 @@ class FtpSourcePoller(cfg: FtpSourceConfig, offsetStorage: OffsetStorageReader) 
       Some(Duration.parse(cfg.getString(FtpSourceConfig.FileMaxAge))),
       monitor2topic.keys.toSeq,
       cfg.timeoutMs(),
-      cfg.getProtocol
+      cfg.getProtocol,
+      cfg.getString(FtpSourceConfig.fileFilter)
     ),
       fileConverter
     )

--- a/kafka-connect-ftp/src/test/scala/com/datamountaineer/streamreactor/connect/ftp/source/EndToEnd.scala
+++ b/kafka-connect-ftp/src/test/scala/com/datamountaineer/streamreactor/connect/ftp/source/EndToEnd.scala
@@ -48,7 +48,7 @@ class EmbeddedFtpServer extends StrictLogging {
   val username = "my-User_name7"
   val password = "=541%2@$;;'`"
   val host = "localhost"
-  val port = 22221 // TODO: find free port
+  val port = 3332 // TODO: find free port
   val rootDir = File.newTemporaryDirectory().path
 
   var server: FtpServer = null
@@ -120,7 +120,6 @@ class EndToEndTests extends FunSuite with Matchers with BeforeAndAfter with Stri
   val s1 = "Hebban olla vogala nestas hagunnan hinase hic enda thu wat unbidan we nu\r\n\t\u0000:)".getBytes
   val s2 = "<mandatory quote to show off erudition here>".getBytes
   val s3 = "!".getBytes
-
   val t0 = "/tails/t0"
   val t1 = "/tails/t1"
   val u0 = "/updates/u0"
@@ -159,7 +158,9 @@ class EndToEndTests extends FunSuite with Matchers with BeforeAndAfter with Stri
     FtpSourceConfig.MonitorTail -> "/tails/:tails",
     FtpSourceConfig.MonitorUpdate -> "/updates/:updates",
     FtpSourceConfig.FileMaxAge -> "P7D",
-    FtpSourceConfig.KeyStyle -> "string"
+    FtpSourceConfig.KeyStyle -> "string",
+    FtpSourceConfig.fileFilter -> ".*"
+
   )
 
   def validateSourceRecords(recs:Seq[SourceRecord], diffs:Seq[(String,String,FileDiff)], keyStyle: KeyStyle = KeyStyle.String) = {
@@ -183,6 +184,8 @@ class EndToEndTests extends FunSuite with Matchers with BeforeAndAfter with Stri
   val fileToTopic = Map(t0 -> "tails", t1 -> "tails", u0 -> "updates", u1 -> "updates")
 
   test("Happy flow: file updates are properly reflected by corresponding SourceRecords with structured keys") {
+
+
     val fs = new FileSystem(server.rootDir).clear
     server.start()
 
@@ -199,6 +202,7 @@ class EndToEndTests extends FunSuite with Matchers with BeforeAndAfter with Stri
 
     server.stop()
   }
+
 
   test("Happy flow: file updates are properly reflected by corresponding SourceRecords with stringed keys") {
     val fs = new FileSystem(server.rootDir).clear

--- a/kafka-connect-ftp/src/test/scala/com/datamountaineer/streamreactor/connect/ftp/source/RegExTest.scala
+++ b/kafka-connect-ftp/src/test/scala/com/datamountaineer/streamreactor/connect/ftp/source/RegExTest.scala
@@ -1,0 +1,25 @@
+package com.datamountaineer.streamreactor.connect.ftp.source
+
+import com.datamountaineer.streamreactor.connect.ftp.source
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import org.apache.commons.net.ftp.FTPFile
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
+
+class RegExTest extends FunSuite with Matchers with BeforeAndAfter with StrictLogging with MockitoSugar  {
+  def mockFile(name: String) = {
+    val f = mock[FTPFile]
+    when(f.isFile).thenReturn(true)
+    when(f.isDirectory).thenReturn(false)
+    when(f.getName()).thenReturn(name)
+    f
+  }
+  test("Matches RegEx"){
+    FtpSourceConfig.fileFilter -> ".*"
+
+    var f : source.AbsoluteFtpFile = new AbsoluteFtpFile(mockFile("file.txt"),"\\");
+    f.name.matches(".*") shouldBe true
+    f.name.matches("a") shouldBe false
+  }
+}


### PR DESCRIPTION
Most of the times you don't want all files in a certain directory to be processed. Added support for filtering files via RegEx pattern to the FTP Connector. Makes it possible to tell the connector to select files that only match a certain pattern set in the config. Default behaviour is matching all.
