### PR TITLE
fix(kafka-connect-jms): Ensure JMSSessionProvider only creates JMS Consumers and JMS Producers when appropriate.

### DIFF
--- a/kafka-connect-jms/build.gradle
+++ b/kafka-connect-jms/build.gradle
@@ -24,7 +24,7 @@ project(":kafka-connect-jms") {
 
     dependencies {
         compile("javax.jms:javax.jms-api:$jmsVersion")
-        testCompile("org.apache.activemq:activemq-core:5.7.0")
+        testCompile("org.apache.activemq:activemq-all:5.14.5")
         testCompile("org.json4s:json4s-native_$scalaMajorVersion:$json4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-core_$scalaMajorVersion:$avro4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-macros_$scalaMajorVersion:$avro4sVersion")

--- a/kafka-connect-jms/build.gradle
+++ b/kafka-connect-jms/build.gradle
@@ -23,8 +23,8 @@ project(":kafka-connect-jms") {
     }
 
     dependencies {
-        compile("org.apache.activemq:activemq-core:5.7.0")
         compile("javax.jms:javax.jms-api:$jmsVersion")
+        testCompile("org.apache.activemq:activemq-core:5.7.0")
         testCompile("org.json4s:json4s-native_$scalaMajorVersion:$json4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-core_$scalaMajorVersion:$avro4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-macros_$scalaMajorVersion:$avro4sVersion")

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
@@ -88,20 +88,24 @@ object JMSSessionProvider extends StrictLogging {
         throw new ConnectException(f)
     }
 
-    val topicsConsumers = configureDestination(TopicDestination, context, session, settings, sink)
-                            .flatMap({ case (source, ms, topic) => createConsumers(source, session, topic, settings.subscriptionName, ms)}).toMap
 
-    val queueConsumers = configureDestination(QueueDestination, context, session, settings, sink)
-                            .flatMap({ case (source, ms, queue) => createConsumers(source, session, queue, settings.subscriptionName, ms) }).toMap
+    sink match {
+      case false => {
+        val topicsConsumers = configureDestination(TopicDestination, context, session, settings, sink)
+          .flatMap({ case (source, ms, topic) => createConsumers(source, session, topic, settings.subscriptionName, ms)}).toMap
+        val queueConsumers = configureDestination(QueueDestination, context, session, settings, sink)
+          .flatMap({ case (source, ms, queue) => createConsumers(source, session, queue, settings.subscriptionName, ms) }).toMap
+        new JMSSessionProvider(queueConsumers, topicsConsumers, Map[String, MessageProducer](), Map[String, MessageProducer](), session, connection, context)
+      }
+      case true => {
+        val topicProducers = configureDestination(TopicDestination, context, session, settings, sink)
+          .flatMap({ case (source, _, topic) => createProducers(source, session, topic) }).toMap
 
-
-    val topicProducers = configureDestination(TopicDestination, context, session, settings, sink)
-                            .flatMap({ case (source, _, topic) => createProducers(source, session, topic) }).toMap
-
-    val queueProducers = configureDestination(QueueDestination, context, session, settings, sink)
-                            .flatMap({ case (source, _, queue) => createProducers(source, session, queue) }).toMap
-
-    new JMSSessionProvider(queueConsumers, topicsConsumers, queueProducers, topicProducers, session, connection, context)
+        val queueProducers = configureDestination(QueueDestination, context, session, settings, sink)
+          .flatMap({ case (source, _, queue) => createProducers(source, session, queue) }).toMap
+        new JMSSessionProvider(Map[String, MessageConsumer](), Map[String, MessageConsumer](), queueProducers, topicProducers, session, connection, context)
+      }
+    }
   }
 
   def configureDestination(destinationType: DestinationType, context: InitialContext, session: Session, settings: JMSSettings, sink: Boolean = false): List[(String, Option[String], Destination)] = {

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
@@ -16,14 +16,17 @@
 
 package com.datamountaineer.streamreactor.connect
 
-import java.io.{BufferedWriter, ByteArrayOutputStream, FileWriter}
+import java.io.{BufferedWriter, ByteArrayOutputStream, File, FileWriter}
+import java.net.ServerSocket
 import java.nio.file.Paths
 import java.util.UUID
-import javax.jms.{BytesMessage, Session, TextMessage}
+import javax.jms.{BytesMessage, Connection, Session, TextMessage}
 
 import com.datamountaineer.streamreactor.connect.converters.source.AvroConverter
 import com.datamountaineer.streamreactor.connect.jms.config.{DestinationSelector, JMSConfigConstants}
 import com.sksamuel.avro4s.{AvroOutputStream, SchemaFor}
+import org.apache.activemq.ActiveMQConnectionFactory
+import org.apache.activemq.broker.BrokerService
 import org.apache.activemq.jndi.ActiveMQInitialContextFactory
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
@@ -100,18 +103,18 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
     ).asJava
   }
 
-  def getProps1Topic = {
+  def getProps1Topic(url: String = JMS_URL)  = {
     Map(JMSConfigConstants.KCQL -> KCQL_SOURCE_TOPIC,
       JMSConfigConstants.JMS_USER -> JMS_USER,
       JMSConfigConstants.JMS_PASSWORD -> JMS_PASSWORD,
       JMSConfigConstants.INITIAL_CONTEXT_FACTORY -> INITIAL_CONTEXT_FACTORY,
       JMSConfigConstants.CONNECTION_FACTORY -> CONNECTION_FACTORY,
-      JMSConfigConstants.JMS_URL -> JMS_URL
+      JMSConfigConstants.JMS_URL -> url
     ).asJava
   }
 
   def getProps1TopicWithMessageSelector(url: String = JMS_URL, msgSelector: String = MESSAGE_SELECTOR) = {
-    getProps1Topic.asScala ++
+    getProps1Topic(url).asScala ++
       Map(JMSConfigConstants.KCQL -> kcqlWithMessageSelector(msgSelector),
         JMSConfigConstants.JMS_URL -> url)
   }.asJava
@@ -269,4 +272,32 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
 
   def kcqlWithMessageSelector(msgSelector: String) =
     s"INSERT INTO $TOPIC1 SELECT * FROM $JMS_TOPIC1 WITHTYPE TOPIC WITHJMSSELECTOR=`$msgSelector`"
+
+  def getFreePort() = {
+    val socket = new ServerSocket(0)
+    socket.setReuseAddress(true)
+    socket.getLocalPort
+  }
+
+  def testWithBrokerOnPort(port: Int = getFreePort())(test: (Connection, String) => Unit) = {
+    val broker = new BrokerService()
+    broker.setPersistent(false)
+    broker.setUseJmx(false)
+    broker.setDeleteAllMessagesOnStartup(true)
+    val brokerUrl = s"tcp://localhost:$port"
+    broker.addConnector(brokerUrl)
+    broker.setUseShutdownHook(false)
+    val property = "java.io.tmpdir"
+    val tempDir = System.getProperty(property)
+    broker.setDataDirectoryFile( new File(tempDir))
+    broker.setTmpDataDirectory( new File(tempDir))
+    broker.start()
+
+    val connectionFactory = new ActiveMQConnectionFactory()
+    connectionFactory.setBrokerURL(brokerUrl)
+    val conn = connectionFactory.createConnection()
+    conn.start()
+
+    test(conn, brokerUrl)
+  }
  }

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
@@ -273,13 +273,15 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
   def kcqlWithMessageSelector(msgSelector: String) =
     s"INSERT INTO $TOPIC1 SELECT * FROM $JMS_TOPIC1 WITHTYPE TOPIC WITHJMSSELECTOR=`$msgSelector`"
 
-  def getFreePort() = {
+  def getFreePort:Int = {
     val socket = new ServerSocket(0)
     socket.setReuseAddress(true)
     socket.getLocalPort
   }
 
-  def testWithBrokerOnPort(port: Int = getFreePort())(test: (Connection, String) => Unit) = {
+  def testWithBrokerOnPort(test: (Connection, String) => Unit):Unit = testWithBrokerOnPort() (test: (Connection, String) => Unit)
+
+  def testWithBrokerOnPort(port: Int = getFreePort) (test: (Connection, String) => Unit): Unit = {
     val broker = new BrokerService()
     broker.setPersistent(false)
     broker.setUseJmx(false)

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/config/JMSSettingsTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/config/JMSSettingsTest.scala
@@ -46,7 +46,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll {
   }
 
   "should create a JMSSettings for a source with only 1 topic for a source" in {
-    val props = getProps1Topic
+    val props = getProps1Topic()
     val config = JMSConfig(props)
     val settings = JMSSettings(config, false)
     val setting = settings.settings.head

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
@@ -42,7 +42,7 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
     Path(AVRO_FILE).delete()
   }
 
-  "should read message from JMS queue without converters" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+  "should read message from JMS queue without converters" in testWithBrokerOnPort { (conn, brokerUrl) =>
 
     val messageCount = 9
 
@@ -64,7 +64,7 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
     }
   }
 
-  "should read and convert to avro" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+  "should read and convert to avro" in testWithBrokerOnPort { (conn, brokerUrl) =>
 
     val messageCount = 10
 
@@ -89,7 +89,7 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
     }
   }
 
-  "should read messages from JMS queue with message selector" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+  "should read messages from JMS queue with message selector" in testWithBrokerOnPort { (conn, brokerUrl) =>
     val messageCount = 10
 
     val session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE)

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
@@ -42,7 +42,7 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
     Path(AVRO_FILE).delete()
   }
 
-  "should read message from JMS queue without converters" in testWithBrokerOnPort(61631) { (conn, brokerUrl) =>
+  "should read message from JMS queue without converters" in testWithBrokerOnPort() { (conn, brokerUrl) =>
 
     val messageCount = 9
 
@@ -64,7 +64,7 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
     }
   }
 
-  "should read and convert to avro" in testWithBrokerOnPort(61632) { (conn, brokerUrl) =>
+  "should read and convert to avro" in testWithBrokerOnPort() { (conn, brokerUrl) =>
 
     val messageCount = 10
 
@@ -89,7 +89,7 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
     }
   }
 
-  "should read messages from JMS queue with message selector" in testWithBrokerOnPort(61633) { (conn, brokerUrl) =>
+  "should read messages from JMS queue with message selector" in testWithBrokerOnPort() { (conn, brokerUrl) =>
     val messageCount = 10
 
     val session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE)
@@ -129,25 +129,4 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
     }
   }
 
-  def testWithBrokerOnPort(port: Int)(test: (Connection, String) => Unit) = {
-    val broker = new BrokerService()
-    broker.setPersistent(false)
-    broker.setUseJmx(false)
-    broker.setDeleteAllMessagesOnStartup(true)
-    val brokerUrl = s"tcp://localhost:$port"
-    broker.addConnector(brokerUrl)
-    broker.setUseShutdownHook(false)
-    val property = "java.io.tmpdir"
-    val tempDir = System.getProperty(property)
-    broker.setDataDirectoryFile( new File(tempDir))
-    broker.setTmpDataDirectory( new File(tempDir))
-    broker.start()
-
-    val connectionFactory = new ActiveMQConnectionFactory()
-    connectionFactory.setBrokerURL(brokerUrl)
-    val conn = connectionFactory.createConnection()
-    conn.start()
-
-    test(conn, brokerUrl)
-  }
 }

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSessionProviderTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSessionProviderTest.scala
@@ -11,7 +11,7 @@ class JMSSessionProviderTest extends TestBase with BeforeAndAfterAll with Eventu
   val forAJmsConsumer = false
   val forAJmsProducer = true
 
-  "should only create JMS Queue Consumer when reading from JMS Queue" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+  "should only create JMS Queue Consumer when reading from JMS Queue" in testWithBrokerOnPort { (conn, brokerUrl) =>
     val props = getProps1Queue(brokerUrl)
     val config = JMSConfig(props)
     val settings = JMSSettings(config, forAJmsConsumer)
@@ -23,7 +23,7 @@ class JMSSessionProviderTest extends TestBase with BeforeAndAfterAll with Eventu
     provider.topicProducers.size shouldBe 0
   }
 
-  "should only create JMS Topic Consumer when reading from JMS Topic" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+  "should only create JMS Topic Consumer when reading from JMS Topic" in testWithBrokerOnPort { (conn, brokerUrl) =>
     val props = getProps1Topic(brokerUrl)
     val config = JMSConfig(props)
     val settings = JMSSettings(config, forAJmsConsumer)
@@ -35,7 +35,7 @@ class JMSSessionProviderTest extends TestBase with BeforeAndAfterAll with Eventu
     provider.topicProducers.size shouldBe 0
   }
 
-  "should only create JMS Queue Producer when writing to JMS Queue" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+  "should only create JMS Queue Producer when writing to JMS Queue" in testWithBrokerOnPort { (conn, brokerUrl) =>
     val props = getProps1Queue(brokerUrl)
     val config = JMSConfig(props)
     val settings = JMSSettings(config, forAJmsProducer)
@@ -47,7 +47,7 @@ class JMSSessionProviderTest extends TestBase with BeforeAndAfterAll with Eventu
     provider.topicProducers.size shouldBe 0
   }
 
-  "should only create JMS Topic Producer when writing to JMS Topic" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+  "should only create JMS Topic Producer when writing to JMS Topic" in testWithBrokerOnPort { (conn, brokerUrl) =>
     val props = getProps1Topic(brokerUrl)
     val config = JMSConfig(props)
     val settings = JMSSettings(config, forAJmsProducer)

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSessionProviderTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSessionProviderTest.scala
@@ -1,0 +1,61 @@
+package com.datamountaineer.streamreactor.connect.source
+
+import com.datamountaineer.streamreactor.connect.TestBase
+import com.datamountaineer.streamreactor.connect.jms.JMSSessionProvider
+import com.datamountaineer.streamreactor.connect.jms.config.{JMSConfig, JMSSettings}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+
+class JMSSessionProviderTest extends TestBase with BeforeAndAfterAll with Eventually {
+
+  val forAJmsConsumer = false
+  val forAJmsProducer = true
+
+  "should only create JMS Queue Consumer when reading from JMS Queue" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+    val props = getProps1Queue(brokerUrl)
+    val config = JMSConfig(props)
+    val settings = JMSSettings(config, forAJmsConsumer)
+    val provider = JMSSessionProvider(settings, forAJmsConsumer)
+
+    provider.queueConsumers.size shouldBe 1
+    provider.queueProducers.size shouldBe 0
+    provider.topicsConsumers.size shouldBe 0
+    provider.topicProducers.size shouldBe 0
+  }
+
+  "should only create JMS Topic Consumer when reading from JMS Topic" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+    val props = getProps1Topic(brokerUrl)
+    val config = JMSConfig(props)
+    val settings = JMSSettings(config, forAJmsConsumer)
+    val provider = JMSSessionProvider(settings, forAJmsConsumer)
+
+    provider.queueConsumers.size shouldBe 0
+    provider.queueProducers.size shouldBe 0
+    provider.topicsConsumers.size shouldBe 1
+    provider.topicProducers.size shouldBe 0
+  }
+
+  "should only create JMS Queue Producer when writing to JMS Queue" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+    val props = getProps1Queue(brokerUrl)
+    val config = JMSConfig(props)
+    val settings = JMSSettings(config, forAJmsProducer)
+    val provider = JMSSessionProvider(settings, forAJmsProducer)
+
+    provider.queueConsumers.size shouldBe 0
+    provider.queueProducers.size shouldBe 1
+    provider.topicsConsumers.size shouldBe 0
+    provider.topicProducers.size shouldBe 0
+  }
+
+  "should only create JMS Topic Producer when writing to JMS Topic" in testWithBrokerOnPort() { (conn, brokerUrl) =>
+    val props = getProps1Topic(brokerUrl)
+    val config = JMSConfig(props)
+    val settings = JMSSettings(config, forAJmsProducer)
+    val provider = JMSSessionProvider(settings, forAJmsProducer)
+
+    provider.queueConsumers.size shouldBe 0
+    provider.queueProducers.size shouldBe 0
+    provider.topicsConsumers.size shouldBe 0
+    provider.topicProducers.size shouldBe 1
+  }
+}


### PR DESCRIPTION
JMS Consumers are only created when in 'source' mode and JMS Producers are only created when in 'sink' mode.

Refactored some of the supporting test code so that the ActiveMQ brokers are started on a free port if none is specified at construction time. This prevents port collisions between tests and allows tests to potentially be run in parallel.

Fixes #330