### PR TITLE
Fix JMS connector message acking.

### DIFF
--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSourceTaskTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSourceTaskTest.scala
@@ -75,16 +75,15 @@ class JMSSourceTaskTest extends TestBase with BeforeAndAfterAll with Eventually 
       m.acknowledge()
     })
 
-    eventually {
+    val processedRecords = eventually {
       val records = task.poll().asScala
       records.size shouldBe 10
       records.head.valueSchema().toString shouldBe JMSStructMessage.getSchema().toString
+      messagesLeftToAckShouldBe(10)
+      records
     }
 
-    messagesLeftToAckShouldBe(10)
-
-    task.poll()
-    task.commit()
+    processedRecords.foreach(task.commitRecord)
 
     messagesLeftToAckShouldBe(0)
 


### PR DESCRIPTION
There is a problem using the Kafka Connect `commit()` method detailed [here](https://issues.apache.org/jira/browse/KAFKA-5716). We observed messages being acked when there was a task failure (eg. schema registry being unavailable) even though they had not been processed.

We have followed a suggested fix which is to override the more granular `commitRecord(SourceRecord record)` method and keep track of records that need to be committed.
  