### PR TITLE
Close connection to broker when shutting down a task.

### DIFF
--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
@@ -45,29 +45,11 @@ case class JMSSessionProvider(queueConsumers: Map[String, MessageConsumer],
     connection.start()
   }
 
-  def close(): Try[Unit] = {
-    topicsConsumers.foreach({ case(source, consumer) =>
-      logger.info(s"Stopping topic consumer for $source")
-      consumer.close()
-    })
-    queueConsumers.foreach({ case(source, consumer) =>
-      logger.info(s"Stopping queue consumer for $source")
-      consumer.close()
-    })
-
-    topicProducers.foreach({ case(source, producer) =>
-      logger.info(s"Stopping topic producer for $source")
-      producer.close()
-    })
-
-    queueProducers.foreach({ case(source, producer) =>
-      logger.info(s"Stopping queue producer for $source")
-      producer.close()
-    })
-
-    Try(session.close())
-    Try(context.close())
-  }
+  def close(): Try[Unit] =
+    for {
+      _ <- Try(connection.close())
+      _ <- Try(context.close())
+    } yield ()
 }
 
 object JMSSessionProvider extends StrictLogging {

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceTask.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceTask.scala
@@ -28,8 +28,8 @@ import org.apache.kafka.connect.source.{SourceRecord, SourceTask}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
-
 import scala.collection.mutable
+import scala.util.{Failure, Success}
 
 /**
   * Created by andrew@datamountaineer.com on 10/03/2017. 
@@ -56,7 +56,11 @@ class JMSSourceTask extends SourceTask with StrictLogging {
 
   override def stop(): Unit = {
     logger.info("Stopping JMS readers")
-    reader.stop
+
+    reader.stop match {
+      case Failure(t) => logger.error(s"Error encountered while stopping JMS Source Task. $t")
+      case Success(_) => logger.info("Successfully stopped JMS Source Task.")
+    }
   }
 
   override def poll(): util.List[SourceRecord] = {


### PR DESCRIPTION
Previously the JMS connector was not closing the connection to the broker when a source task was shut down which could cause issues when reconnecting.