### PR TITLE
Add a polling timeout to the JMS connector.

### DIFF
--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
@@ -57,6 +57,9 @@ object JMSConfig {
     .define(JMSConfigConstants.BATCH_SIZE, Type.INT, JMSConfigConstants.BATCH_SIZE_DEFAULT, Importance.MEDIUM,
       JMSConfigConstants.BATCH_SIZE_DOC,
       "Connection", 13, ConfigDef.Width.MEDIUM, JMSConfigConstants.BATCH_SIZE)
+    .define(JMSConfigConstants.POLLING_TIMEOUT_CONFIG, Type.LONG, JMSConfigConstants.POLLING_TIMEOUT_DEFAULT, Importance.MEDIUM,
+        JMSConfigConstants.POLLING_TIMEOUT_DOC,
+        "Connection", 14, ConfigDef.Width.MEDIUM, JMSConfigConstants.POLLING_TIMEOUT_CONFIG)
 
     //converters
 

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
@@ -99,4 +99,9 @@ object JMSConfigConstants {
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
+
+  val POLLING_TIMEOUT_CONFIG = s"$CONNECTOR_PREFIX.polling.timeout"
+  val POLLING_TIMEOUT_DOC = "Provides the timeout to poll incoming messages"
+  val POLLING_TIMEOUT_DISPLAY = "Polling timeout"
+  val POLLING_TIMEOUT_DEFAULT = 1000L
 }

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSSettings.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSSettings.scala
@@ -47,7 +47,8 @@ case class JMSSettings(connectionURL: String,
                        password: Option[Password],
                        batchSize: Int,
                        errorPolicy: ErrorPolicy = new ThrowErrorPolicy,
-                       retries: Int) {
+                       retries: Int,
+                       pollingTimeout: Long) {
   require(connectionURL != null && connectionURL.trim.length > 0, "Invalid connection URL")
   require(connectionFactoryClass != null, "Invalid class for connection factory")
 }
@@ -72,6 +73,7 @@ object JMSSettings extends StrictLogging {
     val batchSize = config.getInt(JMSConfigConstants.BATCH_SIZE)
     val fields = config.getFieldsMap()
     val ignoreFields = config.getIgnoreFieldsMap()
+    val pollingTimeout = config.getLong(JMSConfigConstants.POLLING_TIMEOUT_CONFIG)
 
     val initialContextFactoryClass = config.getString(JMSConfigConstants.INITIAL_CONTEXT_FACTORY)
     val clazz = config.getString(JMSConfigConstants.CONNECTION_FACTORY)
@@ -161,7 +163,8 @@ object JMSSettings extends StrictLogging {
       Option(password),
       batchSize,
       errorPolicy,
-      nbrOfRetries)
+      nbrOfRetries,
+      pollingTimeout)
   }
 
   def getFormatType(kcql: Kcql) : FormatType = Option(kcql.getFormatType).getOrElse(FormatType.JSON)


### PR DESCRIPTION
Quick fix to stop the high CPU usage in the connector (currently there is a tight loop around polling for messages as it hardly blocks). In the future we can introduce queues which consumers add messages to and probably then improve the acknowledgement mechanism.