### PR TITLE
Adds PK joiner separator for Elastic Sink 5 and 6

### DIFF
--- a/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/ElasticJsonWriter.scala
@@ -29,15 +29,14 @@ import com.landoop.sql.Field
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Indexable
 import com.typesafe.scalalogging.slf4j.StrictLogging
-import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.connect.sink.SinkRecord
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy
 
 import scala.collection.JavaConversions._
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Try
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
   extends ErrorHandler with StrictLogging with ConverterUtil {
@@ -134,7 +133,7 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
                     )
 
                     require(pks.nonEmpty, "Error extracting primary keys")
-                    update(pks.mkString(".")).in(i / documentType).docAsUpsert(json)(IndexableJsonNode)
+                    update(pks.mkString(settings.pkJoinerSeparator)).in(i / documentType).docAsUpsert(json)(IndexableJsonNode)
                 }
               }
 

--- a/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticConfig.scala
+++ b/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticConfig.scala
@@ -118,6 +118,16 @@ object ElasticConfig {
       ConfigDef.Width.LONG,
       ElasticConfigConstants.KCQL)
     .define(
+      ElasticConfigConstants.PK_JOINER_SEPARATOR,
+      Type.STRING,
+      ElasticConfigConstants.PK_JOINER_SEPARATOR_DEFAULT,
+      Importance.LOW,
+      ElasticConfigConstants.PK_JOINER_SEPARATOR_DOC,
+      "KCQL",
+      2,
+      ConfigDef.Width.SHORT,
+      ElasticConfigConstants.PK_JOINER_SEPARATOR)
+    .define(
       ElasticConfigConstants.ES_CLUSTER_XPACK_SETTINGS,
       Type.PASSWORD,
       ElasticConfigConstants.ES_CLUSTER_XPACK_SETTINGS_DEFAULT,

--- a/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticConfigConstants.scala
+++ b/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticConfigConstants.scala
@@ -91,4 +91,9 @@ object ElasticConfigConstants {
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
+
+  val PK_JOINER_SEPARATOR =  s"$CONNECTOR_PREFIX.pk.separator"
+  val PK_JOINER_SEPARATOR_DOC = "Separator used when have more that one field in PK"
+  val PK_JOINER_SEPARATOR_DEFAULT = "."
+  val PK_JOINER_SEPARATOR_DISPLAY = "PK joiner separator"
 }

--- a/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticSettings.scala
+++ b/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticSettings.scala
@@ -36,13 +36,16 @@ case class ElasticSettings(kcqls: Seq[Kcql],
                            xPackSettings: Map[String, String] = Map.empty,
                            xPackPlugins: Seq[Class[_ <: Plugin]] = Seq.empty,
                            clientType: ClientType = ClientType.TCP,
-                           batchSize: Int = ElasticConfigConstants.BATCH_SIZE_DEFAULT)
+                           batchSize: Int = ElasticConfigConstants.BATCH_SIZE_DEFAULT,
+                           pkJoinerSeparator: String = ElasticConfigConstants.PK_JOINER_SEPARATOR_DEFAULT
+                          )
 
 
 object ElasticSettings {
 
   def apply(config: ElasticConfig): ElasticSettings = {
     val kcql = config.getKcql()
+    val pkJoinerSeparator = config.getString(ElasticConfigConstants.PK_JOINER_SEPARATOR)
     val writeTimeout = config.getWriteTimeout
     val errorPolicy = config.getErrorPolicy
     val retries = config.getNumberRetries
@@ -89,7 +92,8 @@ object ElasticSettings {
       xPackSettings,
       xPackPlugins,
       clientType,
-      batchSize
+      batchSize,
+      pkJoinerSeparator
     )
   }
 }

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
@@ -29,15 +29,13 @@ import com.landoop.sql.Field
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Indexable
 import com.typesafe.scalalogging.slf4j.StrictLogging
-import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.connect.sink.SinkRecord
-import org.elasticsearch.action.support.WriteRequest.RefreshPolicy
 
 import scala.collection.JavaConversions._
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Try
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
   extends ErrorHandler with StrictLogging with ConverterUtil {
@@ -134,7 +132,7 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
                     )
 
                     require(pks.nonEmpty, "Error extracting primary keys")
-                    update(pks.mkString(".")).in(i / documentType).docAsUpsert(json)(IndexableJsonNode)
+                    update(pks.mkString(settings.pkJoinerSeparator)).in(i / documentType).docAsUpsert(json)(IndexableJsonNode)
                 }
               }
 

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticConfig.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticConfig.scala
@@ -118,6 +118,16 @@ object ElasticConfig {
       ConfigDef.Width.LONG,
       ElasticConfigConstants.KCQL)
     .define(
+      ElasticConfigConstants.PK_JOINER_SEPARATOR,
+      Type.STRING,
+      ElasticConfigConstants.PK_JOINER_SEPARATOR_DEFAULT,
+      Importance.LOW,
+      ElasticConfigConstants.PK_JOINER_SEPARATOR_DOC,
+      "KCQL",
+      2,
+      ConfigDef.Width.SHORT,
+      ElasticConfigConstants.PK_JOINER_SEPARATOR)
+    .define(
       ElasticConfigConstants.ES_CLUSTER_XPACK_SETTINGS,
       Type.PASSWORD,
       ElasticConfigConstants.ES_CLUSTER_XPACK_SETTINGS_DEFAULT,

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticConfigConstants.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticConfigConstants.scala
@@ -91,4 +91,9 @@ object ElasticConfigConstants {
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
+
+  val PK_JOINER_SEPARATOR =  s"$CONNECTOR_PREFIX.pk.separator"
+  val PK_JOINER_SEPARATOR_DOC = "Separator used when have more that one field in PK"
+  val PK_JOINER_SEPARATOR_DEFAULT = "."
+  val PK_JOINER_SEPARATOR_DISPLAY = "PK joiner separator"
 }

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticSettings.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticSettings.scala
@@ -35,13 +35,16 @@ case class ElasticSettings(kcqls: Seq[Kcql],
                            xPackSettings: Map[String, String] = Map.empty,
                            xPackPlugins: Seq[Class[_ <: Plugin]] = Seq.empty,
                            clientType: ClientType = ClientType.TCP,
-                           batchSize: Int = ElasticConfigConstants.BATCH_SIZE_DEFAULT)
+                           batchSize: Int = ElasticConfigConstants.BATCH_SIZE_DEFAULT,
+                           pkJoinerSeparator: String = ElasticConfigConstants.PK_JOINER_SEPARATOR_DEFAULT
+                          )
 
 
 object ElasticSettings {
 
   def apply(config: ElasticConfig): ElasticSettings = {
     val kcql = config.getKcql()
+    val pkJoinerSeparator = config.getString(ElasticConfigConstants.PK_JOINER_SEPARATOR)
     val writeTimeout = config.getWriteTimeout
     val errorPolicy = config.getErrorPolicy
     val retries = config.getNumberRetries
@@ -88,7 +91,8 @@ object ElasticSettings {
       xPackSettings,
       xPackPlugins,
       clientType,
-      batchSize
+      batchSize,
+      pkJoinerSeparator
     )
   }
 }


### PR DESCRIPTION
Adds a new config for choice a delimiter when concatenating fields to PK.

```
connect.elastic.pk.separator=-
```