### PR TITLE
Updates ES connector

### DIFF
--- a/kafka-connect-elastic5/build.gradle
+++ b/kafka-connect-elastic5/build.gradle
@@ -30,7 +30,6 @@ project(":kafka-connect-elastic5") {
             exclude group: "org.scala-lang", module: "scala-library"
             exclude group: "org.scalactic", module: "scalactic_2.11"
         }
-        compile("org.apache.logging.log4j:log4j-core:$log4jVersion")
         compile("org.apache.logging.log4j:log4j-1.2-api:$log4jVersion")
 
         // for the tcp client

--- a/kafka-connect-elastic5/build.gradle
+++ b/kafka-connect-elastic5/build.gradle
@@ -20,7 +20,8 @@ project(":kafka-connect-elastic5") {
         maven { url "https://artifacts.elastic.co/maven" }
     }
     ext {
-        elastic4sVersion = '5.4.11'
+        elastic4sVersion = '5.6.1'
+        log4jVersion = '2.9.1'
         jnaVersion = '3.0.9'
     }
 
@@ -29,6 +30,8 @@ project(":kafka-connect-elastic5") {
             exclude group: "org.scala-lang", module: "scala-library"
             exclude group: "org.scalactic", module: "scalactic_2.11"
         }
+        compile("org.apache.logging.log4j:log4j-core:$log4jVersion")
+        compile("org.apache.logging.log4j:log4j-1.2-api:$log4jVersion")
 
         // for the tcp client
         compile("com.sksamuel.elastic4s:elastic4s-tcp_$scalaMajorVersion:$elastic4sVersion") {

--- a/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/ElasticJsonWriter.scala
@@ -120,7 +120,7 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
                       kcql.hasRetainStructure
                     )
 
-                    indexInto(i / documentType).source(json.toString)
+                    indexInto(i / documentType).pipeline(kcql.getPipeline).source(json.toString)
 
                   case WriteModeEnum.UPSERT =>
                     val (json, pks) = TransformAndExtractPK(

--- a/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/ElasticJsonWriter.scala
@@ -109,31 +109,37 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
           sinkRecords.grouped(settings.batchSize)
             .map { batch =>
               val indexes = batch.map { r =>
+                val (json, pks) = if(kcqlValue.primaryKeysPath.isEmpty) {
+                  (Transform(
+                    kcqlValue.fields,
+                    kcqlValue.ignoredFields,
+                    r.valueSchema(),
+                    r.value(),
+                    kcql.hasRetainStructure
+                  ), Seq.empty)
+                } else {
+                  TransformAndExtractPK(
+                    kcqlValue.fields,
+                    kcqlValue.ignoredFields,
+                    kcqlValue.primaryKeysPath,
+                    r.valueSchema(),
+                    r.value(),
+                    kcql.hasRetainStructure)
+                }
+                val id = pks.mkString(settings.pkJoinerSeparator);
 
                 kcql.getWriteMode match {
                   case WriteModeEnum.INSERT =>
-                    val json = Transform(
-                      kcqlValue.fields,
-                      kcqlValue.ignoredFields,
-                      r.valueSchema(),
-                      r.value(),
-                      kcql.hasRetainStructure
-                    )
+                    val insert = indexInto(i / documentType)
+                      .pipeline(kcql.getPipeline)
+                      .source(json.toString)
 
-                    indexInto(i / documentType).pipeline(kcql.getPipeline).source(json.toString)
-
+                    if (pks.nonEmpty) insert.id(id) else insert
                   case WriteModeEnum.UPSERT =>
-                    val (json, pks) = TransformAndExtractPK(
-                      kcqlValue.fields,
-                      kcqlValue.ignoredFields,
-                      kcqlValue.primaryKeysPath,
-                      r.valueSchema(),
-                      r.value(),
-                      kcql.hasRetainStructure
-                    )
-
                     require(pks.nonEmpty, "Error extracting primary keys")
-                    update(pks.mkString(settings.pkJoinerSeparator)).in(i / documentType).docAsUpsert(json)(IndexableJsonNode)
+                    update(id)
+                      .in(i / documentType)
+                      .docAsUpsert(json)(IndexableJsonNode)
                 }
               }
 

--- a/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticConfigConstants.scala
+++ b/kafka-connect-elastic5/src/main/scala/com/datamountaineer/streamreactor/connect/elastic5/config/ElasticConfigConstants.scala
@@ -94,6 +94,6 @@ object ElasticConfigConstants {
 
   val PK_JOINER_SEPARATOR =  s"$CONNECTOR_PREFIX.pk.separator"
   val PK_JOINER_SEPARATOR_DOC = "Separator used when have more that one field in PK"
-  val PK_JOINER_SEPARATOR_DEFAULT = "."
+  val PK_JOINER_SEPARATOR_DEFAULT = "-"
   val PK_JOINER_SEPARATOR_DISPLAY = "PK joiner separator"
 }

--- a/kafka-connect-elastic5/src/test/scala/com/datamountaineer/streamreactor/connect/elastic5/TestElasticBase.scala
+++ b/kafka-connect-elastic5/src/test/scala/com/datamountaineer/streamreactor/connect/elastic5/TestElasticBase.scala
@@ -38,6 +38,7 @@ trait TestElasticBase extends WordSpec with Matchers with BeforeAndAfter {
   //var TMP : File = _
   val QUERY = s"INSERT INTO $INDEX SELECT * FROM $TOPIC"
   val QUERY_SELECTION = s"INSERT INTO $INDEX SELECT id, string_field FROM $TOPIC"
+  val QUERY_PK = s"INSERT INTO $INDEX SELECT * FROM $TOPIC PK id"
   val UPDATE_QUERY = s"UPSERT INTO $INDEX SELECT * FROM $TOPIC PK id"
   val UPDATE_QUERY_SELECTION = s"UPSERT INTO $INDEX SELECT id, string_field FROM $TOPIC PK id"
 
@@ -163,6 +164,10 @@ trait TestElasticBase extends WordSpec with Matchers with BeforeAndAfter {
 
   def getElasticSinkConfigPropsSelection = {
     getBaseElasticSinkConfigProps(QUERY_SELECTION)
+  }
+
+  def getElasticSinkConfigPropsPk = {
+    getBaseElasticSinkConfigProps(QUERY_PK)
   }
 
   def getElasticSinkUpdateConfigProps = {

--- a/kafka-connect-elastic5/src/test/scala/com/datamountaineer/streamreactor/connect/elastic5/TestElasticWriter.scala
+++ b/kafka-connect-elastic5/src/test/scala/com/datamountaineer/streamreactor/connect/elastic5/TestElasticWriter.scala
@@ -229,4 +229,90 @@ class TestElasticWriter extends TestElasticBase with MockitoSugar {
     client.close()
     TMP.deleteRecursively()
   }
+
+  "A ElasticWriter should insert into with PK Elastic Search a number of records" in {
+    val TMP = File(System.getProperty("java.io.tmpdir") + "/elastic-" + UUID.randomUUID())
+    TMP.createDirectory()
+    //mock the context to return our assignment when called
+    val context = mock[SinkTaskContext]
+    when(context.assignment()).thenReturn(getAssignment)
+    //get test records
+    val testRecords = getTestRecords
+    //get config
+    val config = new ElasticConfig(getElasticSinkConfigPropsPk)
+
+    val localNode = LocalNode(ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT, TMP.toString)
+    val client = localNode.elastic4sclient(true)
+    //get writer
+
+    val settings = ElasticSettings(config)
+    val writer = new ElasticJsonWriter(new TcpKElasticClient(client), settings)
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val res = client.execute {
+      search(INDEX)
+    }.await
+    res.totalHits shouldBe testRecords.size
+
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val resUpdate = client.execute {
+      search(INDEX)
+    }.await
+    resUpdate.totalHits shouldBe testRecords.size
+
+    //close writer
+    writer.close()
+    client.close()
+    TMP.deleteRecursively()
+  }
+
+  "A ElasticWriter should insert into without PK Elastic Search a number of records" in {
+    val TMP = File(System.getProperty("java.io.tmpdir") + "/elastic-" + UUID.randomUUID())
+    TMP.createDirectory()
+    //mock the context to return our assignment when called
+    val context = mock[SinkTaskContext]
+    when(context.assignment()).thenReturn(getAssignment)
+    //get test records
+    val testRecords = getTestRecords
+    //get config
+    val config = new ElasticConfig(getElasticSinkConfigProps)
+
+    val localNode = LocalNode(ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT, TMP.toString)
+    val client = localNode.elastic4sclient(true)
+    //get writer
+
+    val settings = ElasticSettings(config)
+    val writer = new ElasticJsonWriter(new TcpKElasticClient(client), settings)
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val res = client.execute {
+      search(INDEX)
+    }.await
+    res.totalHits shouldBe testRecords.size
+
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val resUpdate = client.execute {
+      search(INDEX)
+    }.await
+    resUpdate.totalHits shouldBe testRecords.size * 2
+
+    //close writer
+    writer.close()
+    client.close()
+    TMP.deleteRecursively()
+  }
 }

--- a/kafka-connect-elastic5/src/test/scala/com/datamountaineer/streamreactor/connect/elastic5/TestElasticWriter.scala
+++ b/kafka-connect-elastic5/src/test/scala/com/datamountaineer/streamreactor/connect/elastic5/TestElasticWriter.scala
@@ -308,7 +308,7 @@ class TestElasticWriter extends TestElasticBase with MockitoSugar {
     val resUpdate = client.execute {
       search(INDEX)
     }.await
-    resUpdate.totalHits shouldBe testRecords.size * 2
+    resUpdate.totalHits shouldBe testRecords.size
 
     //close writer
     writer.close()

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
@@ -119,7 +119,7 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
                       kcql.hasRetainStructure
                     )
 
-                    indexInto(i / documentType).source(json.toString)
+                    indexInto(i / documentType).pipeline(kcql.getPipeline).source(json.toString)
 
                   case WriteModeEnum.UPSERT =>
                     val (json, pks) = TransformAndExtractPK(

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
@@ -108,31 +108,37 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
           sinkRecords.grouped(settings.batchSize)
             .map { batch =>
               val indexes = batch.map { r =>
+                val (json, pks) = if(kcqlValue.primaryKeysPath.isEmpty) {
+                  (Transform(
+                    kcqlValue.fields,
+                    kcqlValue.ignoredFields,
+                    r.valueSchema(),
+                    r.value(),
+                    kcql.hasRetainStructure
+                  ), Seq.empty)
+                } else {
+                  TransformAndExtractPK(
+                    kcqlValue.fields,
+                    kcqlValue.ignoredFields,
+                    kcqlValue.primaryKeysPath,
+                    r.valueSchema(),
+                    r.value(),
+                    kcql.hasRetainStructure)
+                }
+                val id = pks.mkString(settings.pkJoinerSeparator);
 
                 kcql.getWriteMode match {
                   case WriteModeEnum.INSERT =>
-                    val json = Transform(
-                      kcqlValue.fields,
-                      kcqlValue.ignoredFields,
-                      r.valueSchema(),
-                      r.value(),
-                      kcql.hasRetainStructure
-                    )
+                    val insert = indexInto(i / documentType)
+                      .pipeline(kcql.getPipeline)
+                      .source(json.toString)
 
-                    indexInto(i / documentType).pipeline(kcql.getPipeline).source(json.toString)
-
+                    if (pks.nonEmpty) insert.id(id) else insert
                   case WriteModeEnum.UPSERT =>
-                    val (json, pks) = TransformAndExtractPK(
-                      kcqlValue.fields,
-                      kcqlValue.ignoredFields,
-                      kcqlValue.primaryKeysPath,
-                      r.valueSchema(),
-                      r.value(),
-                      kcql.hasRetainStructure
-                    )
-
                     require(pks.nonEmpty, "Error extracting primary keys")
-                    update(pks.mkString(settings.pkJoinerSeparator)).in(i / documentType).docAsUpsert(json)(IndexableJsonNode)
+                    update(id)
+                      .in(i / documentType)
+                      .docAsUpsert(json)(IndexableJsonNode)
                 }
               }
 

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/ElasticJsonWriter.scala
@@ -125,18 +125,18 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
                     r.value(),
                     kcql.hasRetainStructure)
                 }
-                val id = pks.mkString(settings.pkJoinerSeparator);
+                val idFromPk = pks.mkString(settings.pkJoinerSeparator);
 
                 kcql.getWriteMode match {
                   case WriteModeEnum.INSERT =>
-                    val insert = indexInto(i / documentType)
+                    indexInto(i / documentType)
                       .pipeline(kcql.getPipeline)
+                      .id(if (idFromPk.isEmpty) autoGenId(r) else idFromPk)
                       .source(json.toString)
 
-                    if (pks.nonEmpty) insert.id(id) else insert
                   case WriteModeEnum.UPSERT =>
                     require(pks.nonEmpty, "Error extracting primary keys")
-                    update(id)
+                    update(idFromPk)
                       .in(i / documentType)
                       .docAsUpsert(json)(IndexableJsonNode)
                 }
@@ -152,6 +152,16 @@ class ElasticJsonWriter(client: KElasticClient, settings: ElasticSettings)
         Await.result(Future.sequence(fut), settings.writeTimeout.seconds)
       )
     )
+  }
+
+  /**
+    * Create id from record infos
+    *
+    * @param record One SinkRecord
+    **/
+  def autoGenId(record: SinkRecord): String = {
+    val pks = Seq(record.topic(), record.kafkaPartition(), record.kafkaOffset())
+    pks.mkString(settings.pkJoinerSeparator)
   }
 
   private case class KcqlValues(fields: Seq[Field],

--- a/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticConfigConstants.scala
+++ b/kafka-connect-elastic6/src/main/scala/com/datamountaineer/streamreactor/connect/elastic6/config/ElasticConfigConstants.scala
@@ -94,6 +94,6 @@ object ElasticConfigConstants {
 
   val PK_JOINER_SEPARATOR =  s"$CONNECTOR_PREFIX.pk.separator"
   val PK_JOINER_SEPARATOR_DOC = "Separator used when have more that one field in PK"
-  val PK_JOINER_SEPARATOR_DEFAULT = "."
+  val PK_JOINER_SEPARATOR_DEFAULT = "-"
   val PK_JOINER_SEPARATOR_DISPLAY = "PK joiner separator"
 }

--- a/kafka-connect-elastic6/src/test/scala/com/datamountaineer/streamreactor/connect/elastic6/TestElasticBase.scala
+++ b/kafka-connect-elastic6/src/test/scala/com/datamountaineer/streamreactor/connect/elastic6/TestElasticBase.scala
@@ -37,6 +37,7 @@ trait TestElasticBase extends WordSpec with Matchers with BeforeAndAfter {
   val INDEX_WITH_DATE = s"${INDEX}_${LocalDateTime.now.format(ofPattern("YYYY-MM-dd"))}"
   //var TMP : File = _
   val QUERY = s"INSERT INTO $INDEX SELECT * FROM $TOPIC"
+  val QUERY_PK = s"INSERT INTO $INDEX SELECT * FROM $TOPIC PK id"
   val QUERY_SELECTION = s"INSERT INTO $INDEX SELECT id, string_field FROM $TOPIC"
   val UPDATE_QUERY = s"UPSERT INTO $INDEX SELECT * FROM $TOPIC PK id"
   val UPDATE_QUERY_SELECTION = s"UPSERT INTO $INDEX SELECT id, string_field FROM $TOPIC PK id"
@@ -163,6 +164,10 @@ trait TestElasticBase extends WordSpec with Matchers with BeforeAndAfter {
 
   def getElasticSinkConfigPropsSelection = {
     getBaseElasticSinkConfigProps(QUERY_SELECTION)
+  }
+
+  def getElasticSinkConfigPropsPk = {
+    getBaseElasticSinkConfigProps(QUERY_PK)
   }
 
   def getElasticSinkUpdateConfigProps = {

--- a/kafka-connect-elastic6/src/test/scala/com/datamountaineer/streamreactor/connect/elastic6/TestElasticWriter.scala
+++ b/kafka-connect-elastic6/src/test/scala/com/datamountaineer/streamreactor/connect/elastic6/TestElasticWriter.scala
@@ -229,4 +229,91 @@ class TestElasticWriter extends TestElasticBase with MockitoSugar {
     client.close()
     TMP.deleteRecursively()
   }
+
+
+  "A ElasticWriter should insert into with PK Elastic Search a number of records" in {
+    val TMP = File(System.getProperty("java.io.tmpdir") + "/elastic-" + UUID.randomUUID())
+    TMP.createDirectory()
+    //mock the context to return our assignment when called
+    val context = mock[SinkTaskContext]
+    when(context.assignment()).thenReturn(getAssignment)
+    //get test records
+    val testRecords = getTestRecords
+    //get config
+    val config = new ElasticConfig(getElasticSinkConfigPropsPk)
+
+    val localNode = LocalNode(ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT, TMP.toString)
+    val client = localNode.elastic4sclient(true)
+    //get writer
+
+    val settings = ElasticSettings(config)
+    val writer = new ElasticJsonWriter(new TcpKElasticClient(client), settings)
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val res = client.execute {
+      search(INDEX)
+    }.await
+    res.totalHits shouldBe testRecords.size
+
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val resUpdate = client.execute {
+      search(INDEX)
+    }.await
+    resUpdate.totalHits shouldBe testRecords.size
+
+    //close writer
+    writer.close()
+    client.close()
+    TMP.deleteRecursively()
+  }
+
+  "A ElasticWriter should insert into without PK Elastic Search a number of records" in {
+    val TMP = File(System.getProperty("java.io.tmpdir") + "/elastic-" + UUID.randomUUID())
+    TMP.createDirectory()
+    //mock the context to return our assignment when called
+    val context = mock[SinkTaskContext]
+    when(context.assignment()).thenReturn(getAssignment)
+    //get test records
+    val testRecords = getTestRecords
+    //get config
+    val config = new ElasticConfig(getElasticSinkConfigProps)
+
+    val localNode = LocalNode(ElasticConfigConstants.ES_CLUSTER_NAME_DEFAULT, TMP.toString)
+    val client = localNode.elastic4sclient(true)
+    //get writer
+
+    val settings = ElasticSettings(config)
+    val writer = new ElasticJsonWriter(new TcpKElasticClient(client), settings)
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val res = client.execute {
+      search(INDEX)
+    }.await
+    res.totalHits shouldBe testRecords.size
+
+    //write records to elastic
+    writer.write(testRecords)
+
+    Thread.sleep(2000)
+    //check counts
+    val resUpdate = client.execute {
+      search(INDEX)
+    }.await
+    resUpdate.totalHits shouldBe testRecords.size * 2
+
+    //close writer
+    writer.close()
+    client.close()
+    TMP.deleteRecursively()
+  }
 }

--- a/kafka-connect-elastic6/src/test/scala/com/datamountaineer/streamreactor/connect/elastic6/TestElasticWriter.scala
+++ b/kafka-connect-elastic6/src/test/scala/com/datamountaineer/streamreactor/connect/elastic6/TestElasticWriter.scala
@@ -309,7 +309,7 @@ class TestElasticWriter extends TestElasticBase with MockitoSugar {
     val resUpdate = client.execute {
       search(INDEX)
     }.await
-    resUpdate.totalHits shouldBe testRecords.size * 2
+    resUpdate.totalHits shouldBe testRecords.size
 
     //close writer
     writer.close()


### PR DESCRIPTION
1 - Adds pipeline option #266 
2 - Adds PK like id for insert operation
3 - Adds auto generator id for insert operation with consumed message info 
4 - Change pk separator default
5 - Update elastic4s version in ES5 connector