### PR TITLE
Connector DELETE in waiting interval step

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -329,7 +329,12 @@ class CassandraTableReader(private val name: String,
     }
 
     // add source record to queue
-    while (!queue.offer(record, 1, TimeUnit.SECONDS)) {
+    var shouldStop = false
+    while (!queue.offer(record, 1, TimeUnit.SECONDS) & !shouldStop) {
+      shouldStop = stop.get()
+    }
+    if(shouldStop){
+      throw new ConnectException(s"Connector $name stopped for table $keySpace.$table.")
     }
   }
 


### PR DESCRIPTION
When connector is in waiting interval step and you send "DELETE /connectors". Kafka connect worker has problem for stop thread.

And when connector is paused state and you send "DELETE /connectors". Kafka connect worker has problem for stop thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/391)
<!-- Reviewable:end -->
