### PR TITLE
Add to cassandra-sink support json-unset

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -401,6 +401,15 @@ object CassandraConfigSink {
       1,
       ConfigDef.Width.MEDIUM,
       CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS_DISPLAY)
+    .define(CassandraConfigConstants.DEFAULT_VALUE_SERVE_STRATEGY_PROPERTY,
+      Type.STRING,
+      CassandraConfigConstants.DEFAULT_VALUE_SERVE_STRATEGY_DEFAULT,
+      Importance.LOW,
+      CassandraConfigConstants.DEFAULT_VALUE_SERVE_STRATEGY_DOC,
+      "Mappings",
+      1,
+      ConfigDef.Width.MEDIUM,
+      CassandraConfigConstants.DEFAULT_VALUE_SERVE_STRATEGY_DISPLAY)
 }
 
 case class CassandraConfigSink(props: util.Map[String, String])

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -192,4 +192,14 @@ object CassandraConfigConstants {
   val MAPPING_COLLECTION_TO_JSON = s"$CONNECTOR_PREFIX.mapping.collection.to.json"
   val MAPPING_COLLECTION_TO_JSON_DOC = "Mapping columns with type Map, List and Set like json"
   val MAPPING_COLLECTION_TO_JSON_DEFAULT = true
+
+  val DEFAULT_VALUE_SERVE_STRATEGY_PROPERTY = s"$CONNECTOR_PREFIX.default.value"
+  val DEFAULT_VALUE_SERVE_STRATEGY_DOC =
+    """
+      |By default a column omitted from the ``JSON`` map will be set to ``NULL``.
+      |Alternatively, if set ``UNSET``, pre-existing value  will be preserved.
+    """.stripMargin
+
+  val DEFAULT_VALUE_SERVE_STRATEGY_DEFAULT = ""
+  val DEFAULT_VALUE_SERVE_STRATEGY_DISPLAY = "Default value serve strategy"
 }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -19,6 +19,7 @@ package com.datamountaineer.streamreactor.connect.cassandra.config
 import java.lang.Boolean
 
 import com.datamountaineer.kcql.{Field, Kcql}
+import com.datamountaineer.streamreactor.connect.cassandra.config.DefaultValueServeStrategy.DefaultValueServeStrategy
 import com.datamountaineer.streamreactor.connect.cassandra.config.TimestampType.TimestampType
 import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicy, ThrowErrorPolicy}
 import com.datastax.driver.core.ConsistencyLevel
@@ -67,7 +68,8 @@ case class CassandraSinkSetting(keySpace: String,
                                 enableProgress: Boolean = CassandraConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
                                 deleteEnabled: Boolean = CassandraConfigConstants.DELETE_ROW_ENABLED_DEFAULT,
                                 deleteStatement: String = CassandraConfigConstants.DELETE_ROW_STATEMENT_DEFAULT,
-                                deleteStructFields: Seq[String] = Seq.empty) extends CassandraSetting
+                                deleteStructFields: Seq[String] = Seq.empty,
+                                defaultValueStrategy: Option[DefaultValueServeStrategy] = None) extends CassandraSetting
 
 /**
   * Cassandra Setting used for both Readers and writers
@@ -146,6 +148,8 @@ object CassandraSettings extends StrictLogging {
 
     val structFlds = config.getList(CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS)
 
+    val defaultValueStrategy  = DefaultValueServeStrategy.of(config.getString(CassandraConfigConstants.DEFAULT_VALUE_SERVE_STRATEGY_PROPERTY))
+
     CassandraSinkSetting(keySpace,
       kcqls,
       fields,
@@ -157,6 +161,17 @@ object CassandraSettings extends StrictLogging {
       enableCounter,
       deleteEnabled,
       deleteStmt,
-      structFlds)
+      structFlds,
+      defaultValueStrategy)
+  }
+}
+
+
+object DefaultValueServeStrategy extends Enumeration {
+  type DefaultValueServeStrategy = Value
+  val NULL, UNSET = Value
+
+  def of(value: String): Option[DefaultValueServeStrategy] = {
+    Try(withName(value)).toOption
   }
 }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterUnset.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterUnset.scala
@@ -1,0 +1,180 @@
+package com.datamountaineer.streamreactor.connect.cassandra.sink
+
+import java.util.UUID
+import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
+import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigConstants
+import com.datastax.driver.core.Session
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpec}
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder}
+
+import scala.collection.JavaConverters._
+
+@DoNotDiscover
+class TestCassandraJsonWriterUnset
+    extends WordSpec
+    with Matchers
+    with MockitoSugar
+    with TestConfig
+    with BeforeAndAfterAll {
+
+  val keyspace = "sink"
+  val contactPoint = "localhost"
+  val userName = "cassandra"
+  val password = "cassandra"
+  var session : Session = _
+
+  override def beforeAll {
+    session = createKeySpace(keyspace ,secure = true, ssl = false)
+  }
+
+  override def afterAll(): Unit = {
+    session.close()
+    session.getCluster.close()
+  }
+
+  "a Cassandra json unset feature" should {
+    "pre-existing values will be preserved " in {
+      val colA_expected = 3L
+      val colB_expected = 5L
+
+      def getRecords(table: String): (SinkRecord, SinkRecord) = {
+        val schema = SchemaBuilder.string().build()
+
+        val record        = s"""{"id":"1","col_a":4,"col_b":$colB_expected}"""
+        val partialRecord = s"""{"id":"1","col_a":$colA_expected}"""  // absent col_b
+
+        (
+          new SinkRecord(table,
+                         0,
+                         Schema.STRING_SCHEMA,
+                         "key",
+                         schema,
+                         record,
+                         0,
+                         System.currentTimeMillis(),
+                         TimestampType.LOG_APPEND_TIME),
+          new SinkRecord(table,
+                         0,
+                         Schema.STRING_SCHEMA,
+                         "key",
+                         schema,
+                         partialRecord,
+                         0,
+                         System.currentTimeMillis(),
+                         TimestampType.LOG_APPEND_TIME)
+        )
+      }
+
+      val table = "A" + UUID.randomUUID().toString.replace("-", "_")
+      val kcql = s"INSERT INTO $table SELECT * FROM TOPICA"
+
+      session.execute(s"""CREATE TABLE IF NOT EXISTS $keyspace.$table (
+        id text PRIMARY KEY
+        , col_a bigint
+        , col_b bigint)""")
+
+      val context = mock[SinkTaskContext]
+      val assignment = getAssignment
+      when(context.assignment()).thenReturn(assignment)
+      val testRecords = getRecords("TOPICA")
+      val config = Map(
+        CassandraConfigConstants.CONTACT_POINTS -> contactPoint,
+        CassandraConfigConstants.KEY_SPACE -> keyspace,
+        CassandraConfigConstants.USERNAME -> userName,
+        CassandraConfigConstants.PASSWD -> password,
+        CassandraConfigConstants.KCQL -> kcql,
+        CassandraConfigConstants.DEFAULT_VALUE_SERVE_STRATEGY_PROPERTY -> "UNSET"
+      ).asJava
+
+      val task = new CassandraSinkTask()
+      task.initialize(context)
+      task.start(config)
+
+      val (init, part) = testRecords
+      println(part)
+
+      task.put(Seq(init).asJava)
+      task.put(Seq(part).asJava)
+      task.stop()
+
+      val res = session.execute(s"SELECT * FROM $keyspace.$table")
+      val row = res.one()
+      row.getLong("col_a") shouldBe colA_expected
+      row.getLong("col_b") shouldBe colB_expected
+    }
+
+    "pre-existing values will be set to null (default behavior)" in {
+      val colA_expected = 3L
+      val colB_unexpected = 5L
+
+      def getRecords(table: String): (SinkRecord, SinkRecord) = {
+        val schema = SchemaBuilder.string().build()
+
+        val record        = s"""{"id":"1","col_a":4,"col_b":$colB_unexpected}"""
+        val partialRecord = s"""{"id":"1","col_a":$colA_expected}"""  // absent col_b
+
+        (
+          new SinkRecord(table,
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            schema,
+            record,
+            0,
+            System.currentTimeMillis(),
+            TimestampType.LOG_APPEND_TIME),
+          new SinkRecord(table,
+            0,
+            Schema.STRING_SCHEMA,
+            "key",
+            schema,
+            partialRecord,
+            0,
+            System.currentTimeMillis(),
+            TimestampType.LOG_APPEND_TIME)
+        )
+      }
+
+      //val table = "A" + UUID.randomUUID().toString.replace("-", "_")
+      val table = "fake"
+      val kcql = s"INSERT INTO $table SELECT * FROM TOPICA"
+
+      session.execute(s"""CREATE TABLE IF NOT EXISTS $keyspace.$table (
+        id text PRIMARY KEY
+        , col_a bigint
+        , col_b bigint)""")
+
+      val context = mock[SinkTaskContext]
+      val assignment = getAssignment
+      when(context.assignment()).thenReturn(assignment)
+      val testRecords = getRecords("TOPICA")
+      val config = Map(
+        CassandraConfigConstants.CONTACT_POINTS -> contactPoint,
+        CassandraConfigConstants.KEY_SPACE -> keyspace,
+        CassandraConfigConstants.USERNAME -> userName,
+        CassandraConfigConstants.PASSWD -> password,
+        CassandraConfigConstants.KCQL -> kcql
+      ).asJava
+
+      val task = new CassandraSinkTask()
+      task.initialize(context)
+      task.start(config)
+
+      val (init, part) = testRecords
+      println(part)
+
+      task.put(Seq(init).asJava)
+      task.put(Seq(part).asJava)
+      task.stop()
+
+      val res = session.execute(s"SELECT * FROM $keyspace.$table")
+      val row = res.one()
+      row.getLong("col_a") shouldBe colA_expected
+      row.getLong("col_b") shouldBe 0   // null value
+    }
+  }
+}


### PR DESCRIPTION
feat(cassandra-sink): Add to cassandra-sink support json-unset

Add support to "unset" JSON fields in prepared statements ( see https://issues.apache.org/jira/browse/CASSANDRA-11424 ).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/402)
<!-- Reviewable:end -->
