### PR TITLE
Adding Link4J dependency to main gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ allprojects {
         confluentVersion = '4.1.0'
         kafkaVersion = '1.1.0'
         dataMountaineerCommonVersion = "1.1.3"
+        link4jVersion = "1.8.0"
 
         gitCommitHash = ("git rev-parse HEAD").execute().text.trim()
         gitTag = ("git describe --abbrev=0 --tags").execute().text.trim()
@@ -198,6 +199,8 @@ allprojects {
         compile("com.datamountaineer:kafka-connect-common:$dataMountaineerCommonVersion") {
 
         }
+        compile "org.apache.calcite:calcite-linq4j:$link4jVersion"
+
         testCompile "org.mockito:mockito-core:$mockitoVersion"
         testCompile "org.scalacheck:scalacheck_$scalaMajorVersion:$scalaCheck"
         testCompile "org.scalatest:scalatest_$scalaMajorVersion:$scalaTest"


### PR DESCRIPTION
As discussed per https://github.com/Landoop/stream-reactor/issues/437#issuecomment-392737275, adding the link4j dependency to the main gradle file would benefit projects not containing this dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/453)
<!-- Reviewable:end -->
