### PR TITLE
Bugfix for detecting Sorted Set mode

### DIFF
--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala
@@ -61,44 +61,77 @@ class RedisSinkTask extends SinkTask with StrictLogging {
     //-- Find out the Connector modes (cache | INSERT (SortedSet) | PK (SortedSetS)
 
     // Cache mode requires >= 1 PK and *NO* STOREAS SortedSet setting
-    val modeCache = settings.copy(kcqlSettings =
-      settings.kcqlSettings
-        .filter(k => k.kcqlConfig.getStoredAs == null
-          && k.kcqlConfig.getPrimaryKeys.size() >= 1))
+    val modeCache = filterModeCache(settings)
 
     // Insert Sorted Set mode requires: target name of SortedSet to be defined and STOREAS SortedSet syntax to be provided
-    val mode_INSERT_SS = settings.copy(kcqlSettings =
-      settings.kcqlSettings
-        .filter { k =>
-          Option(k.kcqlConfig.getStoredAs).map(_.toUpperCase).contains("SORTEDSET") &&
-            k.kcqlConfig.getTarget != null &&
-            k.kcqlConfig.getPrimaryKeys == null
-        }
-    )
+    val mode_INSERT_SS = filterModeInsertSS(settings)
 
     // Multiple Sorted Sets mode requires: 1 Primary Key to be defined and STORE SortedSet syntax to be provided
-    val mode_PK_SS = settings.copy(kcqlSettings =
-      settings.kcqlSettings
-        .filter { k =>
-          Option(k.kcqlConfig.getStoredAs).map(_.toUpperCase).contains("SORTEDSET") &&
-            k.kcqlConfig.getPrimaryKeys.length == 1
-        })
+    val mode_PK_SS = filterModePKSS(settings)
 
     //-- Start as many writers as required
-    writer =
-      (modeCache.kcqlSettings.headOption.map { _ =>
-        logger.info("Starting " + modeCache.kcqlSettings.size + " KCQLs with Redis Cache mode")
-        List(new RedisCache(modeCache))
-      } ++ mode_INSERT_SS.kcqlSettings.headOption.map { _ =>
-        logger.info("Starting " + mode_INSERT_SS.kcqlSettings.size + " KCQLs with Redis Insert Sorted Set mode")
-        List(new RedisInsertSortedSet(mode_INSERT_SS))
-      } ++ mode_PK_SS.kcqlSettings.headOption.map { _ =>
-        logger.info("Starting " + mode_PK_SS.kcqlSettings.size + " KCQLs with Redis Multiple Sorted Sets mode")
-        List(new RedisMultipleSortedSets(mode_PK_SS))
-      }).flatten.toList
+    writer = (modeCache.kcqlSettings.headOption.map { _ =>
+      logger.info("Starting " + modeCache.kcqlSettings.size + " KCQLs with Redis Cache mode")
+      List(new RedisCache(modeCache))
+    } ++ mode_INSERT_SS.kcqlSettings.headOption.map { _ =>
+      logger.info("Starting " + mode_INSERT_SS.kcqlSettings.size + " KCQLs with Redis Insert Sorted Set mode")
+      List(new RedisInsertSortedSet(mode_INSERT_SS))
+    } ++ mode_PK_SS.kcqlSettings.headOption.map { _ =>
+      logger.info("Starting " + mode_PK_SS.kcqlSettings.size + " KCQLs with Redis Multiple Sorted Sets mode")
+      List(new RedisMultipleSortedSets(mode_PK_SS))
+    }).flatten.toList
 
     require(writer.nonEmpty, s"No writers set for ${RedisConfigConstants.KCQL_CONFIG}!")
   }
+
+  /**
+    * Construct a RedisSinkSettings object containing all the kcqlConfigs that use the Cache mode.
+    * This function will filter by the absence of the "STOREAS" keyword and the presence of primary keys.
+    *
+    * KCQL Example: INSERT INTO cache SELECT price FROM yahoo-fx PK symbol
+    *
+    * @param settings The RedisSinkSettings containing all kcqlConfigs.
+    * @return A RedisSinkSettings object containing only the kcqlConfigs that use the Cache mode.
+    */
+  def filterModeCache(settings: RedisSinkSettings): RedisSinkSettings = settings.copy(kcqlSettings =
+    settings.kcqlSettings
+      .filter(k => k.kcqlConfig.getStoredAs == null
+        && k.kcqlConfig.getPrimaryKeys.size() >= 1))
+
+  /**
+    * Construct a RedisSinkSettings object containing all the kcqlConfigs that use the Sorted Set mode.
+    * This function will filter by the presence of the "STOREAS" keyword and a target, as well as the absence of primary keys.
+    *
+    * KCQL Example: INSERT INTO cpu_stats SELECT * FROM cpuTopic STOREAS SortedSet(score=timestamp)
+    *
+    * @param settings The RedisSinkSettings containing all kcqlConfigs.
+    * @return A RedisSinkSettings object containing only the kcqlConfigs that use the Sorted Set mode.
+    */
+  def filterModeInsertSS(settings: RedisSinkSettings): RedisSinkSettings = settings.copy(kcqlSettings =
+    settings.kcqlSettings
+      .filter { k =>
+        Option(k.kcqlConfig.getStoredAs).map(_.toUpperCase).contains("SORTEDSET") &&
+          k.kcqlConfig.getTarget != null &&
+          k.kcqlConfig.getPrimaryKeys.isEmpty
+      }
+  )
+
+  /**
+    * Constructs a RedisSinkSettings object containing all the kcqlConfigs that use the Multiple Sorted Sets mode.
+    * This function will filter by the presence of the "STOREAS" keyword and the presence of primary keys.
+    *
+    * KCQL Example: SELECT temperature, humidity FROM sensorsTopic PK sensorID STOREAS SortedSet(score=timestamp)
+    *
+    * @param settings The RedisSinkSettings containing all kcqlConfigs.
+    * @return A RedisSinkSettings object containing only the kcqlConfigs that use the Multiple Sorted Sets mode.
+    */
+  def filterModePKSS(settings: RedisSinkSettings): RedisSinkSettings = settings.copy(kcqlSettings =
+    settings.kcqlSettings
+      .filter { k =>
+        Option(k.kcqlConfig.getStoredAs).map(_.toUpperCase).contains("SORTEDSET") &&
+          k.kcqlConfig.getPrimaryKeys.length == 1
+      }
+  )
 
   /**
     * Pass the SinkRecords to the writer for Writing

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
@@ -52,7 +52,7 @@ object RedisSinkSettings {
     val nbrOfRetries = config.getNumberRetries
 
     // Get the aliases
-    val aliases = config.getFieldsAliases().toSeq
+    val aliases = config.getFieldsAliases()
     // Get the ignored fields
     val ignoredFields = kcqlConfigs.map(r => r.getIgnoredFields.map(f => f.getName).toSet)
     // Get connection info
@@ -64,7 +64,13 @@ object RedisSinkSettings {
     val size = kcqlConfigs.length
 
     val allRedisKCQLSettings = (0 until size).map { i =>
-      RedisKCQLSetting(kcqlConfigs.get(i).getSource, kcqlConfigs(i), builders(i), aliases(i), ignoredFields(i))
+      RedisKCQLSetting(
+        kcqlConfigs.get(i).getSource,
+        kcqlConfigs(i),
+        builders(i),
+        aliases(i),
+        ignoredFields(i)
+      )
     }.toSet
 
     RedisSinkSettings(connectionInfo, allRedisKCQLSettings, errorPolicy, nbrOfRetries)

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTaskTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTaskTest.scala
@@ -1,0 +1,108 @@
+package com.datamountaineer.streamreactor.connect.redis.sink
+
+import com.datamountaineer.streamreactor.connect.redis.sink.config.{RedisConfig, RedisConfigConstants, RedisConnectionInfo, RedisSinkSettings}
+import com.datamountaineer.streamreactor.connect.redis.sink.support.RedisMockSupport
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class RedisSinkTaskTest extends WordSpec with Matchers with RedisMockSupport {
+
+  "work with Cache" -> {
+    val KCQL = s"INSERT INTO cache SELECT price from yahoo-fx PK symbol;"
+    println("Testing mode for KCQL : " + KCQL)
+    val props = Map(
+      RedisConfigConstants.REDIS_HOST->"localhost",
+      RedisConfigConstants.REDIS_PORT->"0000",
+      RedisConfigConstants.KCQL_CONFIG->KCQL
+    ).asJava
+
+    val config = RedisConfig(props)
+    val settings = RedisSinkSettings(config)
+
+    val task = new RedisSinkTask
+    task.filterModeCache(settings).kcqlSettings shouldBe settings.kcqlSettings
+
+    task.filterModeInsertSS(settings).kcqlSettings.isEmpty shouldBe true
+    task.filterModePKSS(settings).kcqlSettings.isEmpty shouldBe true
+  }
+
+  "work with SortedSet" -> {
+    val KCQL = s"INSERT INTO topic-1 SELECT * FROM topic1 STOREAS SortedSet(score=ts);"
+    println("Testing mode for KCQL : " + KCQL)
+    val props = Map(
+      RedisConfigConstants.REDIS_HOST->"localhost",
+      RedisConfigConstants.REDIS_PORT->"0000",
+      RedisConfigConstants.KCQL_CONFIG->KCQL
+    ).asJava
+
+    val config = RedisConfig(props)
+    val settings = RedisSinkSettings(config)
+
+    val task = new RedisSinkTask
+    task.filterModeInsertSS(settings).kcqlSettings shouldBe settings.kcqlSettings
+
+    task.filterModeCache(settings).kcqlSettings.isEmpty shouldBe true
+    task.filterModePKSS(settings).kcqlSettings.isEmpty shouldBe true
+  }
+
+  "work with Multiple SortedSets" -> {
+    val KCQL = s"SELECT temperature, humidity FROM sensorsTopic PK sensorID STOREAS SortedSet(score=timestamp);"
+    println("Testing mode for KCQL : " + KCQL)
+    val props = Map(
+      RedisConfigConstants.REDIS_HOST->"localhost",
+      RedisConfigConstants.REDIS_PORT->"0000",
+      RedisConfigConstants.KCQL_CONFIG->KCQL
+    ).asJava
+
+    val config = RedisConfig(props)
+    val settings = RedisSinkSettings(config)
+
+    val task = new RedisSinkTask
+    task.filterModePKSS(settings).kcqlSettings shouldBe settings.kcqlSettings
+
+    task.filterModeCache(settings).kcqlSettings.isEmpty shouldBe true
+    task.filterModeInsertSS(settings).kcqlSettings.isEmpty shouldBe true
+  }
+
+  "work with Multiple Modes" -> {
+    val KCQL =
+      s"SELECT temperature, humidity FROM sensorsTopic PK sensorID STOREAS SortedSet(score=timestamp);" +
+      s"SELECT temperature, humidity FROM sensorsTopic2 PK sensorID STOREAS SortedSet(score=timestamp);" +
+      s"INSERT INTO cache1 SELECT price from yahoo-fx PK symbol;" +
+      s"INSERT INTO cache2 SELECT price from googl-fx PK symbol;" +
+      s"INSERT INTO cache3 SELECT price from appl-fx PK symbol;" +
+      s"INSERT INTO topic-1 SELECT * FROM topic1 STOREAS SortedSet(score=ts);" +
+      s"INSERT INTO topic-2 SELECT * FROM topic2 STOREAS SortedSet(score=ts);"
+    println("Testing mode for KCQL : " + KCQL)
+    val props = Map(
+      RedisConfigConstants.REDIS_HOST->"localhost",
+      RedisConfigConstants.REDIS_PORT->"0000",
+      RedisConfigConstants.KCQL_CONFIG->KCQL
+    ).asJava
+
+    val config = RedisConfig(props)
+    val settings = RedisSinkSettings(config)
+
+    val task = new RedisSinkTask
+
+    //Verify filtered cacheSettings
+    val cacheSettings = task.filterModeCache(settings).kcqlSettings
+    cacheSettings.size shouldBe 3
+    cacheSettings.exists(_.kcqlConfig.getSource == "yahoo-fx") shouldBe true
+    cacheSettings.exists(_.kcqlConfig.getSource == "googl-fx") shouldBe true
+    cacheSettings.exists(_.kcqlConfig.getSource == "appl-fx") shouldBe true
+
+    //Verify filtered Sorted Set settings
+    val ssSettings = task.filterModeInsertSS(settings).kcqlSettings
+    ssSettings.size shouldBe 2
+    ssSettings.exists(_.kcqlConfig.getSource == "topic1") shouldBe true
+    ssSettings.exists(_.kcqlConfig.getSource == "topic2") shouldBe true
+
+    //Verify filtered Multiple Sorted Set settings
+    val mssSettings = task.filterModePKSS(settings).kcqlSettings
+    mssSettings.size shouldBe 2
+    mssSettings.exists(_.kcqlConfig.getSource == "sensorsTopic") shouldBe true
+    mssSettings.exists(_.kcqlConfig.getSource == "sensorsTopic2") shouldBe true
+  }
+}


### PR DESCRIPTION
**Problem description:**
When using a KCQL statement that uses the Sorted Set mode, this is not being picked up by the RedisSinkTask, more specifically, not by this check: https://github.com/Landoop/stream-reactor/blob/master/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala#L75

This seems to be due to the fact that the primary keys array is an empty array, rather than it being null when no primary keys are provided in the KCQL statement. This results in the application throwing an exception stating that no writers were set per https://github.com/Landoop/stream-reactor/blob/master/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala#L100

This PR includes a patch for this issue, where the primary key array will be checked for its length rather than it being null, as well as Scala Tests to verify that this patch does indeed resolve aforementioned problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/454)
<!-- Reviewable:end -->
