### PR TITLE
Fixed JMS missing password on authentication process (on lookup)

### DIFF
--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
@@ -139,7 +139,7 @@ object JMSSessionProvider extends StrictLogging {
     props.setProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY, settings.initialContextClass)
     props.setProperty(javax.naming.Context.PROVIDER_URL, settings.connectionURL)
     props.setProperty(javax.naming.Context.SECURITY_PRINCIPAL, settings.user.getOrElse(""))
-    props.setProperty(javax.naming.Context.SECURITY_AUTHENTICATION, settings.password.getOrElse(new Password("")).value())
+    props.setProperty(javax.naming.Context.SECURITY_CREDENTIALS, settings.password.getOrElse(new Password("")).value())
     settings.extraProps.map(e => e.map { case (k,v) => props.setProperty(k, v) })
     props
   }


### PR DESCRIPTION
The JMS sink is not sending the password because of the wrong InitialContext argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/455)
<!-- Reviewable:end -->
