### PR TITLE
Document lacking support for schemaless JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ allprojects {
         confluentVersion = '4.1.0'
         kafkaVersion = '1.1.0'
         dataMountaineerCommonVersion = "1.1.3"
+        link4jVersion = "1.8.0"
 
         gitCommitHash = ("git rev-parse HEAD").execute().text.trim()
         gitTag = ("git describe --abbrev=0 --tags").execute().text.trim()
@@ -198,6 +199,8 @@ allprojects {
         compile("com.datamountaineer:kafka-connect-common:$dataMountaineerCommonVersion") {
 
         }
+        compile "org.apache.calcite:calcite-linq4j:$link4jVersion"
+
         testCompile "org.mockito:mockito-core:$mockitoVersion"
         testCompile "org.scalacheck:scalacheck_$scalaMajorVersion:$scalaCheck"
         testCompile "org.scalatest:scalatest_$scalaMajorVersion:$scalaTest"

--- a/kafka-connect-redis/README.md
+++ b/kafka-connect-redis/README.md
@@ -77,3 +77,5 @@ Once information is stored inside a Redis sorted sets - we can query for i.e. ye
 zrangebyscore USD2GBP <currentTimeInMillis - 86400000> <currentTimeInMillis>
 ```
 
+# Limitations
+- This plugin requires JSON to be parsed using the AVRO Converter and therefore does not support schemaless JSON.


### PR DESCRIPTION
Just adding a note to the README to notify users that this plugin cannot be used for sinking schemaless JSON to Redis.

This would have saved me quite some time as this is an absolute requirement for our project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/457)
<!-- Reviewable:end -->
