### PR TITLE
Fix and enhance mongodb sink key handling (Fix for #450)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ allprojects {
         // The following 4 need to align to compile against a particular version
         confluentVersion = '4.1.0'
         kafkaVersion = '1.1.0'
-        dataMountaineerCommonVersion = "1.1.3"
+        dataMountaineerCommonVersion = "1.1.5"
         link4jVersion = "1.8.0"
 
         gitCommitHash = ("git rev-parse HEAD").execute().text.trim()

--- a/kafka-connect-mongodb/build.gradle
+++ b/kafka-connect-mongodb/build.gradle
@@ -16,7 +16,7 @@
 
 project(":kafka-connect-mongodb") {
     ext {
-        mongoVersion = "3.6.3"
+        mongoVersion = "3.6.4"
         avro4sVersion = "1.6.4"
     }
 

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettings.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettings.scala
@@ -54,7 +54,7 @@ object MongoSettings extends StrictLogging {
     val kcql = config.getKCQL
     val errorPolicy= config.getErrorPolicy
     val retries = config.getNumberRetries
-    val rowKeyBuilderMap = config.getUpsertKeys()
+    val rowKeyBuilderMap = config.getUpsertKeys(preserveFullKeys=true)
     val fieldsMap = config.getFieldsMap(kcql)
     val ignoreFields = config.getIgnoreFieldsMap()
 

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractor.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractor.scala
@@ -68,12 +68,6 @@ object KeysExtractor {
 
   def fromMap(map: java.util.Map[String, Any], keys: Set[String]): ListSet[(String, Any)] = {
 
-    // map of long name to "short" name (last name after the dot) in "A.B.C":
-    val longToShort = keys.map{ long =>
-      val tLong = long.trim
-      val short = tLong.split('.').last
-      (tLong, short) }.toMap
-
     // SCALA 2.12 WARNING: remove the 'reverse' when you upgrade to 2.12;
     // the insertion order of ListSet.toList is preserved in 2.12:
     ListSet( keys.toList.reverse.map{ longKey =>
@@ -101,19 +95,13 @@ object KeysExtractor {
         }
       }
 
-      val short = longToShort(longKey)
+      val short = longKey.trim.split('.').last
       val value = getValue(segments, map)
       (short, value)
     }:_*)
   }
 
   def fromJson(jvalue: JValue, keys: Set[String]): List[(String, Any)] = {
-
-    // map of long name to "short" name (last name after the dot) in "A.B.C":
-    val longToShort = keys.map{ long =>
-      val tLong = long.trim
-      val short = tLong.split('.').last
-      (tLong, short) }.toMap
 
     // SCALA 2.12 WARNING: remove the 'reverse' when you upgrade to 2.12;
     // the insertion order of ListSet.toList is preserved in 2.12:
@@ -140,7 +128,7 @@ object KeysExtractor {
         }
       }
 
-      val short = longToShort(longKey)
+      val short = longKey.trim.split('.').last
       val value = getValue(segments, jvalue)
       (short, value)
     }

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/MongoWriter.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/MongoWriter.scala
@@ -81,6 +81,7 @@ class MongoWriter(settings: MongoSettings, mongoClient: MongoClient) extends Str
             record,
             settings.keyBuilderMap.getOrElse(record.topic(), Set.empty)
           )(settings)
+
           val keysAndValuesList = keysAndValues.toList
           if (keysAndValuesList.nonEmpty) {
             if (keysAndValuesList.size > 1) {
@@ -90,17 +91,30 @@ class MongoWriter(settings: MongoSettings, mongoClient: MongoClient) extends Str
               document.append("_id", keysAndValuesList.head._2)
             }
           }
-
+          
           config.getWriteMode match {
             case WriteModeEnum.INSERT => new InsertOneModel[Document](document)
 
             case WriteModeEnum.UPSERT =>
+
               require(keysAndValues.nonEmpty, "Need to provide keys and values to identify the record to upsert")
+
+              // Need to remove the _id field from the document when upserting.
+              document.remove("_id")
+
               val filter = {
                 if (keysAndValuesList.size == 1) {
-                  Filters.eq("_id", keysAndValuesList.head._2)
+                  val v = keysAndValuesList.head._2
+                  Filters.eq("_id", v)
                 } else {
-                  Filters.and(keysAndValues.map { case (k, v) => Filters.eq(s"_id.$k", v) }.toList: _*)
+
+                  val h = keysAndValuesList.head
+                  val value = new Document(h._1, h._2)
+                  keysAndValuesList.tail.map{ case (k,v) =>
+                    value.append(k, v)
+                  }
+
+                  Filters.eq("_id", value)
                 }
               }
 

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
@@ -64,6 +64,14 @@ class KeysExtractorTest extends WordSpec with Matchers {
       actual shouldBe Set("key1" -> 12, "key3" -> "tripple")
     }
 
+    "extract embedded keys out of a Map" in {
+      import scala.collection.JavaConverters._
+      val actual = KeysExtractor.fromMap(
+        Map("A"->0, "B"->"0", "C"->Map("M"->"1000", "N"->Map("X"->10, "Y"->100).asJava).asJava).asJava,
+        ListSet( "B", "C.M", "C.N.X" ))
+      actual shouldBe ListSet("B"->"0", "M"->"1000", "X"->10)
+    }
+
     "extract keys from a Map should throw an exception if the key is another map" in {
       intercept[ConfigException] {
         KeysExtractor.fromMap(Map("key1" -> 12, "key2" -> 10L, "key3" -> Map.empty[String, String]), Set("key1", "key3"))

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
@@ -50,6 +50,8 @@ class KeysExtractorTest extends WordSpec with Matchers {
     "extract embedded keys out of JSON" in {
       val jvalue = Json.parseJson("""{"A": 0, "B": "0", "C": {"M": "1000", "N": {"X": 10, "Y": 100} } }""")
       val keys = ListSet( "B", "C.M", "C.N.X" )
+      // SCALA 2.12 WARNING: If you upgrade to 2.12 and this test fails, 
+      // you need to remove the "reverse()" calls in KeysExtractor.scala:
       KeysExtractor.fromJson(jvalue, keys) shouldBe
         List("B"->"0", "M"->"1000", "X"->10)
     }
@@ -72,6 +74,8 @@ class KeysExtractorTest extends WordSpec with Matchers {
       val actual = KeysExtractor.fromMap(
         Map("A"->0, "B"->"0", "C"->Map("M"->"1000", "N"->Map("X"->10, "Y"->100).asJava).asJava).asJava,
         ListSet( "B", "C.M", "C.N.X" ))
+      // SCALA 2.12 WARNING: If you upgrade to 2.12 and this test fails, 
+      // you need to remove the "reverse()" calls in KeysExtractor.scala:
       actual shouldBe ListSet("B"->"0", "M"->"1000", "X"->10)
     }
 
@@ -99,6 +103,8 @@ class KeysExtractorTest extends WordSpec with Matchers {
       val format = RecordFormat[Thing]
       val avro = format.to(Thing(0, "0", CThing("1000", NThing(10, 100))))
       val struct = avroData.toConnectData(avro.getSchema, avro)
+      // SCALA 2.12 WARNING: If you upgrade to 2.12 and this test fails, 
+      // you need to remove the "reverse()" calls in KeysExtractor.scala:
       KeysExtractor.fromStruct(
         struct.value().asInstanceOf[Struct],
         ListSet( "B", "C.M", "C.N.X" )) shouldBe

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
@@ -32,8 +32,11 @@ class KeysExtractorTest extends WordSpec with Matchers {
   private val avroData = new AvroData(4)
 
   case class WithNested(id: Int, nested: SomeTest)
-
   case class SomeTest(name: String, value: Double, flags: Seq[Int], map: Map[String, String])
+
+  case class Thing(A: Int, B: String, C: CThing)
+  case class CThing(M: String, N: NThing)
+  case class NThing(X: Int, Y: Int)
 
   "KeysExtractor" should {
     "extract keys from JSON" in {
@@ -44,19 +47,19 @@ class KeysExtractorTest extends WordSpec with Matchers {
       actual shouldBe List("lock_time" -> 9223372036854775807L, "rbf" -> true)
     }
 
+    "extract embedded keys out of JSON" in {
+      val jvalue = Json.parseJson("""{"A": 0, "B": "0", "C": {"M": "1000", "N": {"X": 10, "Y": 100} } }""")
+      val keys = ListSet( "B", "C.M", "C.N.X" )
+      KeysExtractor.fromJson(jvalue, keys) shouldBe
+        List("B"->"0", "M"->"1000", "X"->10)
+    }
+
     "throw exception when extracting the keys from JSON" in {
       val json = scala.io.Source.fromFile(getClass.getResource(s"/transaction1.json").toURI.getPath).mkString
       val jvalue = Json.parseJson(json)
       intercept[ConfigException] {
         val actual = KeysExtractor.fromJson(jvalue, Set("inputs"))
       }
-    }
-
-    "extract embedded keys out of JSON" in {
-      val jvalue = Json.parseJson("""{"A": 0, "B": "0", "C": {"M": "1000", "N": {"X": 10, "Y": 100} } }""")
-      val keys = ListSet( "B", "C.M", "C.N.X" )
-      KeysExtractor.fromJson(jvalue, keys) shouldBe
-        List("B"->"0", "M"->"1000", "X"->10)
     }
 
     "extract keys from a Map" in {
@@ -90,6 +93,16 @@ class KeysExtractorTest extends WordSpec with Matchers {
       val struct = avroData.toConnectData(avro.getSchema, avro)
       KeysExtractor.fromStruct(struct.value().asInstanceOf[Struct], Set("name")) shouldBe
         Set("name" -> "abc")
+    }
+
+    "extract embedded keys out of a struct" in {
+      val format = RecordFormat[Thing]
+      val avro = format.to(Thing(0, "0", CThing("1000", NThing(10, 100))))
+      val struct = avroData.toConnectData(avro.getSchema, avro)
+      KeysExtractor.fromStruct(
+        struct.value().asInstanceOf[Struct],
+        ListSet( "B", "C.M", "C.N.X" )) shouldBe
+        ListSet("B"->"0", "M"->"1000", "X"->10)
     }
 
     "extract from a struct should throw an exception if a key is an array" in {

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/MongoWriterTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/MongoWriterTest.scala
@@ -20,6 +20,7 @@ import com.datamountaineer.kcql.{Kcql, WriteModeEnum}
 import com.datamountaineer.streamreactor.connect.errors.{NoopErrorPolicy, ThrowErrorPolicy}
 import com.datamountaineer.streamreactor.connect.mongodb.config.MongoSettings
 import com.datamountaineer.streamreactor.connect.mongodb.{Json, Transaction}
+import com.mongodb.client.MongoCursor
 import com.mongodb.client.model.{Filters, InsertOneModel}
 import com.mongodb.{AuthenticationMechanism, MongoClient}
 import de.flapdoodle.embed.mongo.config.{MongodConfigBuilder, Net}
@@ -33,6 +34,9 @@ import org.bson.Document
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
 import scala.collection.JavaConversions._
+import scala.collection.immutable.ListMap
+import org.json4s.jackson.JsonMethods._
+import org.json4s.jackson.Serialization
 
 class MongoWriterTest extends WordSpec with Matchers with BeforeAndAfterAll {
 
@@ -56,6 +60,11 @@ class MongoWriterTest extends WordSpec with Matchers with BeforeAndAfterAll {
   override def afterAll() = {
     mongod.foreach(_.stop())
     mongodExecutable.foreach(_.stop())
+  }
+
+  // create SinkRecord from JSON strings, no schema
+  def createSRStringJson(json: String, recordNum: Int): SinkRecord = {
+    new SinkRecord("topicA", 0, null, null, Schema.STRING_SCHEMA, json, recordNum)
   }
 
   "MongoWriter" should {
@@ -100,7 +109,59 @@ class MongoWriterTest extends WordSpec with Matchers with BeforeAndAfterAll {
       runUpserts(records, settings)
     }
 
+    "upsert records into the target Mongo collection with single-field key" in {
+      val settings = MongoSettings("localhost",
+        "",
+        new Password(""),
+        AuthenticationMechanism.SCRAM_SHA_1,
+        "local",
+        kcql = Set(Kcql.parse("UPSERT INTO upsert_string_json_single_key SELECT * FROM topicA PK C")),
+        keyBuilderMap = Map("topicA" -> Set("C")),
+        Map("topicA" -> Map.empty),
+        Map("topicA" -> Set.empty),
+        NoopErrorPolicy())
 
+      val records = List(
+        """{"A": 0, "B": "0", "C": 10 }""",
+        """{"A": 1, "B": "1", "C": "11" }"""
+      )
+
+      runUpsertsTestKeys(
+        records,
+        createSRStringJson,
+        settings,
+        expectedKeys = Map(
+          0 -> ListMap("C"->10),
+          1 -> ListMap("C"->"11")
+        ))
+    }
+
+    "upsert records into the target Mongo collection with multi-field key" in {
+      val settings = MongoSettings("localhost",
+        "",
+        new Password(""),
+        AuthenticationMechanism.SCRAM_SHA_1,
+        "local",
+        kcql = Set(Kcql.parse("UPSERT INTO upsert_string_json_multikey SELECT * FROM topicA PK B,C")),
+        keyBuilderMap = Map("topicA" -> Set("B", "C")),
+        Map("topicA" -> Map.empty),
+        Map("topicA" -> Set.empty),
+        NoopErrorPolicy())
+
+      val records = List(
+        """{"A": 0, "B": "0", "C": 10 }""",
+        """{"A": 1, "B": "1", "C": "11" }"""
+      )
+
+      runUpsertsTestKeys(
+        records,
+        createSRStringJson,
+        settings, 
+        expectedKeys = Map(
+          0 -> ListMap("B"->"0", "C"-> 10),
+          1 -> ListMap("B"->"1", "C"-> "11")
+        ))
+    }
 
     "insert records into the target Mongo collection with Schema.Struct and payload Struct" in {
       val settings = MongoSettings("localhost",
@@ -357,4 +418,111 @@ class MongoWriterTest extends WordSpec with Matchers with BeforeAndAfterAll {
       docOption.get.get("size") shouldBe 10100 + index
     }
   }
+
+  // Map of record number to Map of key field names and field values.
+  type KeyInfo = Map[ Int, Map[String, Any] ]
+
+  // Note that it is assumed the head in the expectedKeys 2nd map is the 'identifying' 
+  // field so use a Map[ListMap] if you have more than one key field:
+  private def runUpsertsTestKeys(
+    records: Seq[String], // json records to upsert
+    recordToSinkRecordFn: (String, Int) => SinkRecord, // (json, recordNum)
+    settings: MongoSettings,
+    expectedKeys: KeyInfo,
+    markIt: Boolean = false) = {
+
+    implicit val jsonFormats = org.json4s.DefaultFormats
+
+    require(settings.kcql.size == 1)
+    require(settings.kcql.head.getWriteMode == WriteModeEnum.UPSERT)
+    val db = mongoClient.get.getDatabase(settings.database)
+    db.createCollection(settings.kcql.head.getTarget)
+    val collection = db.getCollection(settings.kcql.head.getTarget)
+
+    // Do initial insert of all records with id what we would expect
+    val inserts = records.zipWithIndex.map{ case (record, i) =>
+      val keys = expectedKeys(i)
+      // If key is one field, set _id to that field's value directly.
+      // If key is more than one field, set _id to the map object.
+      val idJson = keys.size match {
+        case 1 => Serialization.write(Map("_id"->keys.head._2))
+        case n if (n > 1) => Serialization.write(Map("_id"->keys))
+        case _ => fail()
+      }
+      val rec = compact(parse(record) merge parse(idJson))
+      println(s"writing rec: $rec")
+      val doc = Document.parse(rec)
+      new InsertOneModel[Document](doc)
+    }
+    collection.bulkWrite(inserts)
+
+    // Now do upsert with an added field
+    val mongoWriter = new MongoWriter(settings, mongoClient.get)
+    val sinkRecords = records.zipWithIndex.map{ case (rec, i) =>
+      val modRec = compact(parse(rec) merge parse(s"""{"newField": $i}"""))
+      recordToSinkRecordFn(modRec, i)
+    }
+    mongoWriter.write(sinkRecords)
+
+    val databases = MongoIterableFn(mongoClient.get.listDatabaseNames()).toSet
+    databases.contains(settings.database) shouldBe true
+
+    val collections = MongoIterableFn(mongoClient.get.getDatabase(settings.database).listCollectionNames())
+      .toSet
+
+    val collectionName = settings.kcql.head.getTarget
+    collections.contains(collectionName) shouldBe true
+
+    val actualCollection = mongoClient.get
+      .getDatabase(settings.database)
+      .getCollection(collectionName)
+
+    // Print out the results to aid debugging.
+    {
+      println("((((((((((((((((((((((((((((((((((((((((((((((((((")
+      val cursor: MongoCursor[Document] = collection.find().iterator()
+      try {
+        while (cursor.hasNext()) {
+          println("DDDDDDDDDDDDDDDDDDDDDDDD doc is "+cursor.next().toJson())
+        }
+      } finally {
+        cursor.close()
+      }
+      println("))))))))))))))))))))))))))))))))))))))))))))))))))))))))))")
+    }
+
+    // check the keys NEW
+    expectedKeys.foreach{ case (index, keys) =>  
+      //(field, k)
+      val identifyingField = keys.headOption.get._1 // (must have at least key)
+      val ifValue = keys.headOption.get._2
+      val docOption: Option[Document] = 
+        MongoIterableFn(actualCollection.find(Filters.eq(identifyingField, ifValue))).headOption
+      // If a head key value was unexpected, this will trigger here b/c we probably can't find the record to test against:
+      docOption.isDefined shouldBe true
+      val doc: Document = docOption.get
+
+      // Check the field we added in the upsert is actually there
+      // If a non-head key value was unexpected, this will trigger here:
+      doc.get("newField") shouldBe index
+
+      doc.get("_id") match {
+        case subDoc: Document =>
+          keys.map{ case (k,v) =>
+            subDoc.get(k) shouldBe v
+            // check the key value matches the input values in the body
+            doc.get(k) shouldBe v
+          }
+        case x => {
+          keys.size shouldBe 1
+          x shouldBe keys.head._2
+          // check the key value matches the input values in the body
+          doc.get(keys.head._1) shouldBe keys.head._2
+        }
+      }
+    }
+
+    actualCollection.count() shouldBe records.size
+  }
+
 }


### PR DESCRIPTION
This fixes KCQL "PK" clauses where there are more than one key listed:  https://github.com/Landoop/stream-reactor/issues/450

It also adds the ability to use "embedded keys", where the keys are embedded in sub-documents in the input.  (For example, so you can do PK clauses like "PK person.address.streetNumber" or something like that.)

This PR depends on https://github.com/Landoop/kafka-connect-common/pull/25, which ensures the proper ordering of the multi-key PK clauses.  Please see that PR as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/473)
<!-- Reviewable:end -->
