### PR TITLE
fix(kudu): Eliminate unbounded range partition

### DIFF
--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
@@ -332,13 +332,16 @@ object DbHandler extends StrictLogging with KuduConverter {
   }
 
   /**
-    * Create a Kudu CreateTableOptions default to hash partition for now
+    * Create a Kudu CreateTableOptions to set the proper partition scheme.  If the table definition
+    * contains a `DISTRIBUTEBY {field} INTO {N} BUCKETS` specification, it will generate a series
+    * of N hash partitions on the specified field, and no range partition.
     *
     * @param config The mapping config
-    * @return a CreateTableConfig
+    * @return a CreateTableOptions
     **/
   private def getCreateTableOptions(config: Kcql): CreateTableOptions = {
     new CreateTableOptions()
       .addHashPartitions(config.getBucketing.getBucketNames.toList, config.getBucketing.getBucketsNumber)
+      .setRangePartitionColumns(List.empty[String])
   }
 }


### PR DESCRIPTION
Auto-creating a kudu table with DISTRIBUTEBY enabled created an unnecessary
unbounded range partition.

Fixes #472

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/474)
<!-- Reviewable:end -->
