### PR TITLE
Add ability to use nested field as PK for RedisCache

### DIFF
--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCache.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCache.scala
@@ -18,11 +18,9 @@ package com.datamountaineer.streamreactor.connect.redis.sink.writer
 
 import com.datamountaineer.kcql.Kcql
 import com.datamountaineer.streamreactor.connect.redis.sink.config.{RedisKCQLSetting, RedisSinkSettings}
-import com.datamountaineer.streamreactor.connect.rowkeys.StringStructFieldsStringKeyBuilder
 import org.apache.kafka.connect.sink.SinkRecord
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 import scala.util.Try
 
 /**
@@ -71,7 +69,7 @@ class RedisCache(sinkSettings: RedisSinkSettings) extends RedisWriter {
                 // We can prefix the name of the <KEY> using the target
                 val optionalPrefix = if (Option(KCQL.kcqlConfig.getTarget).isEmpty) "" else KCQL.kcqlConfig.getTarget.trim
                 // Use first primary key's value and (optional) prefix
-                val keyBuilder = StringStructFieldsStringKeyBuilder(KCQL.kcqlConfig.getPrimaryKeys.map(_.getName))
+                val keyBuilder = RedisFieldsKeyBuilder(KCQL.kcqlConfig.getPrimaryKeys.map(_.toString))
                 val extracted = convert(record, fields = KCQL.fieldsAndAliases, ignoreFields = KCQL.ignoredFields)
                 val key = optionalPrefix + keyBuilder.build(record)
                 val payload = convertValueToJson(extracted).toString
@@ -84,5 +82,4 @@ class RedisCache(sinkSettings: RedisSinkSettings) extends RedisWriter {
         logger.debug(s"Wrote ${sinkRecords.size} rows for topic $topic")
     }
   }
-
 }

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisFieldsKeyBuilder.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisFieldsKeyBuilder.scala
@@ -1,0 +1,60 @@
+package com.datamountaineer.streamreactor.connect.redis.sink.writer
+
+import com.datamountaineer.streamreactor.connect.rowkeys.StringKeyBuilder
+import org.apache.kafka.connect.data.{Field, Schema, Struct}
+import org.apache.kafka.connect.sink.SinkRecord
+
+import scala.annotation.tailrec
+import scala.collection.JavaConversions._
+
+/**
+  * Builds a new key from the payload fields specified
+  *
+  * @param keys The key to build
+  */
+case class RedisFieldsKeyBuilder(keys: Seq[String]) extends StringKeyBuilder {
+  require(keys.nonEmpty, "Keys are empty")
+
+  /**
+    * Builds a row key for a records
+    *
+    * @param record a SinkRecord to build the key for
+    * @return A row key string
+    **/
+  override def build(record: SinkRecord): String = {
+    val struct: Struct = record.value.asInstanceOf[Struct]
+    val schema: Schema = struct.schema
+
+    def extractAvailableFieldNames(schema: Schema): Seq[String] = {
+      if (schema.`type` == Schema.Type.STRUCT) {
+        val fields = schema.fields
+        fields.map(_.name) ++ fields.flatMap { f =>
+          extractAvailableFieldNames(f.schema).map(name => f.name + "." + name)
+        }
+      } else Seq.empty
+    }
+
+    val availableFields = extractAvailableFieldNames(schema)
+    val missingKeys = keys.filterNot(availableFields.contains)
+    require(
+      missingKeys.isEmpty,
+      s"${missingKeys.mkString(",")} keys are not present in the SinkRecord payload: ${availableFields.mkString(", ")}"
+    )
+
+    def getValue(key: String): AnyRef = {
+      @tailrec
+      def findValue(keyParts: List[String], obj: AnyRef): Option[AnyRef] =
+        (obj, keyParts) match {
+          case (f: Field, k :: tail) => findValue(tail, f.schema.field(k))
+          case (s: Struct, k :: tail) => findValue(tail, s.get(k))
+          case (v, _) => Option(v)
+        }
+
+      findValue(key.split('.').toList, struct).getOrElse { throw new IllegalArgumentException(
+        s"$key field value is null. Non null value is required for the fields creating the row key"
+      )}
+    }
+
+    keys.map(getValue).mkString(".")
+  }
+}


### PR DESCRIPTION
Previously, if you were trying to use nested fields in ksql like that: 
```
connect.redis.kcql=INSERT INTO user.state. SELECT * FROM user.state PK auth.userId, connectionId
```
You would have met following error:
```
[2018-07-24 14:25:05,696] ERROR WorkerSinkTask{id=RedisSinkConnector-0} Task threw an uncaught and unrecoverable exception (org.apache.kafka.connect.runtime.WorkerTask)
org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:517)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:288)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:198)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:166)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:170)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:214)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.RuntimeException: java.lang.IllegalArgumentException: requirement failed: userId keys are not present in the SinkRecord payload:connected,connectionId,auth
```
This PR is aimed to add support for using nested fields as primary keys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/484)
<!-- Reviewable:end -->
