### PR TITLE
Support primitive types in `connect.cassandra.delete.struct_flds`

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -173,7 +173,7 @@ object CassandraConfigConstants {
   val DELETE_ROW_STATEMENT_MISSING = s"If $DELETE_ROW_ENABLED is true, $DELETE_ROW_STATEMENT is required."
 
   val DELETE_ROW_STRUCT_FLDS = s"$CONNECTOR_PREFIX.$DELETE_ROW_PREFIX.struct_flds"
-  val DELETE_ROW_STRUCT_FLDS_DOC = s"Fields in the key struct data type used in there delete statement. Comma-separated in the order they are found in $DELETE_ROW_STATEMENT."
+  val DELETE_ROW_STRUCT_FLDS_DOC = s"Fields in the key struct data type used in there delete statement. Comma-separated in the order they are found in $DELETE_ROW_STATEMENT. Keep default value to use the record key as a primitive type."
   val DELETE_ROW_STRUCT_FLDS_DEFAULT = ""
   val DELETE_ROW_STRUCT_FLDS_DISPLAY = "Field names in Key Struct"
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraJsonWriter.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraJsonWriter.scala
@@ -209,9 +209,9 @@ class CassandraJsonWriter(connection: CassandraConnection, settings: CassandraSi
                     val key = record.key()
                     val schema = record.keySchema()
                     if (schema.`type`().isPrimitive) {
-                      if (schema.`type`() == Schema.Type.STRING) {
+                      if (schema.`type`() == Schema.Type.STRING && deleteStructFields.nonEmpty) {
                         // treat key string as JSON
-                        logger.trace("key schema is a String type, treat it like JSON...")
+                        logger.trace("key schema is a String type and deleteStructFields non empty, treat it like JSON...")
                         KeyUtils.keysFromJson(key.toString, deleteStructFields)
                       }
                       else {


### PR DESCRIPTION
At this moment there is no way to use primitive types in `connect.cassandra.delete.struct_flds` if schema type is `Schema.Type.STRING`. Also we cannot use `connect.cassandra.delete.struct_flds` without definition if `connect.cassandra.delete.statement` was defined because we got `InvalidQueryException: Invalid unset value for column` at runtime. I suggest to use default value of `connect.cassandra.delete.struct_flds` for primitive types. On the other hand if we define `connect.cassandra.delete.struct_flds` it represents string key as JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/487)
<!-- Reviewable:end -->
