### PR TITLE
Convert json date time fields to MongoDB datetime values

### DIFF
--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfig.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfig.scala
@@ -45,6 +45,9 @@ object MongoConfig {
 
     .define(MongoConfigConstants.KCQL_CONFIG, Type.STRING, Importance.HIGH, MongoConfigConstants.KCQL_DOC,
       "Mappings", 1, ConfigDef.Width.LONG, MongoConfigConstants.KCQL_CONFIG)
+    .define(MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG, Type.LIST, "",
+      Importance.LOW, MongoConfigConstants.JSON_DATETIME_FIELDS_DOC, "Mappings", 1, ConfigDef.Width.NONE,
+      MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG)
     .define(MongoConfigConstants.ERROR_POLICY_CONFIG, Type.STRING, MongoConfigConstants.ERROR_POLICY_DEFAULT,
       Importance.HIGH, MongoConfigConstants.ERROR_POLICY_DOC, "Error", 1, ConfigDef.Width.LONG,
       MongoConfigConstants.ERROR_POLICY_CONFIG)

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfigConstants.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfigConstants.scala
@@ -69,6 +69,9 @@ object MongoConfigConstants {
   val KCQL_CONFIG = s"$CONNECTOR_PREFIX.kcql"
   val KCQL_DOC = "KCQL expression describing field selection and data routing to the target mongo db."
 
+  val JSON_DATETIME_FIELDS_CONFIG = s"$CONNECTOR_PREFIX.json_datetime_fields"
+  val JSON_DATETIME_FIELDS_DOC = "List of fields that should be converted to ISODate on Mongodb insertion (comma-separated field names).  For JSON topics only.  Fields may be an integral epoch time or an ISO8601 datetime string with an offset (offset required).  If string does not parse to ISO, it will be written as a string instead."
+
   val PROGRESS_COUNTER_ENABLED = "connect.progress.enabled"
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfigConstants.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfigConstants.scala
@@ -70,7 +70,18 @@ object MongoConfigConstants {
   val KCQL_DOC = "KCQL expression describing field selection and data routing to the target mongo db."
 
   val JSON_DATETIME_FIELDS_CONFIG = s"$CONNECTOR_PREFIX.json_datetime_fields"
-  val JSON_DATETIME_FIELDS_DOC = "List of fields that should be converted to ISODate on Mongodb insertion (comma-separated field names).  For JSON topics only.  Fields may be an integral epoch time or an ISO8601 datetime string with an offset (offset required).  If string does not parse to ISO, it will be written as a string instead."
+  val JSON_DATETIME_FIELDS_DOC = """
+    |List of fields that should be converted to ISODate on Mongodb insertion 
+    |(comma-separated field names).  For JSON topics only.  Field values may be 
+    |an integral epoch time or an ISO8601 datetime string with an offset (offset 
+    |or 'Z' required).  If string does not parse to ISO, it will be written as a 
+    |string instead.
+    |Subdocument fields can be referred to as in the following examples: 
+    |  "topLevelFieldName",
+    |  "topLevelSubDocument.FieldName",
+    |  "topLevelParent.subDocument.subDocument2.FieldName", (etc.)
+    |If a field is converted to ISODate and that same field is named as a PK, then
+    |the PK field is also written as an ISODate.""".stripMargin
 
   val PROGRESS_COUNTER_ENABLED = "connect.progress.enabled"
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettings.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettings.scala
@@ -34,7 +34,9 @@ case class MongoSettings(connection: String,
                          fields: Map[String, Map[String, String]],
                          ignoredField: Map[String, Set[String]],
                          errorPolicy: ErrorPolicy,
-                         taskRetries: Int = MongoConfigConstants.NBR_OF_RETIRES_DEFAULT)
+                         taskRetries: Int = MongoConfigConstants.NBR_OF_RETIRES_DEFAULT,
+                         // Set of field name lists:
+                         jsonDateTimeFields: Set[Seq[String]] = Set.empty)
 
 
 object MongoSettings extends StrictLogging {
@@ -74,7 +76,22 @@ object MongoSettings extends StrictLogging {
         fieldsMap,
         ignoreFields,
         errorPolicy,
-        retries
+        retries,
+        getJsonDateTimeFields(config)
     )
+  }
+
+  /**
+    * Parse out the jsonDateTimeFields list into the structure we need.
+    */
+  def getJsonDateTimeFields(config: MongoConfig): Set[Seq[String]] = {
+    import scala.collection.JavaConverters._
+    val set: Set[Seq[String]] =
+      config.getList(MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG).
+        asScala.
+        map{ fullName =>
+          fullName.trim.split('.').toSeq
+        }.toSet
+    set
   }
 }

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettings.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettings.scala
@@ -82,7 +82,12 @@ object MongoSettings extends StrictLogging {
   }
 
   /**
-    * Parse out the jsonDateTimeFields list into the structure we need.
+    * Parse out the jsonDateTimeFields list into the structure we need, which is
+    * a Set of field 'paths'; ie. :
+    *    Set(
+    *      Seq("top-level-field"),
+    *      Seq("top-level-parent", "child1", "child2", "fieldname"),
+    *    )
     */
   def getJsonDateTimeFields(config: MongoConfig): Set[Seq[String]] = {
     import scala.collection.JavaConverters._
@@ -92,6 +97,7 @@ object MongoSettings extends StrictLogging {
         map{ fullName =>
           fullName.trim.split('.').toSeq
         }.toSet
+    logger.info(s"MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG is $set")
     set
   }
 }

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
@@ -23,6 +23,7 @@ import java.util
 import java.util.TimeZone
 
 import com.datamountaineer.streamreactor.connect.mongodb.config.MongoSettings
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.data._
 import org.apache.kafka.connect.errors.DataException
 import org.apache.kafka.connect.sink.SinkRecord
@@ -34,7 +35,7 @@ import scala.annotation.tailrec
 import scala.collection.JavaConversions._
 import scala.util.Try
 
-object SinkRecordConverter {
+object SinkRecordConverter extends StrictLogging {
   private val ISO_DATE_FORMAT: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   private val TIME_FORMAT: SimpleDateFormat = new SimpleDateFormat("HH:mm:ss.SSSZ")
 
@@ -290,31 +291,34 @@ object SinkRecordConverter {
   /**
     * Convert timestamps based on settings' jsonDateTimeFields.
     * @param doc
-    * @return Unit - but the input document is modified in-place!
+    * @return Unit - the input document is modified in-place!
     */
   def convertTimestamps(doc: Document)(implicit settings: MongoSettings): Unit = {
 
     import scala.collection.JavaConverters._
     val fieldSet: Set[Seq[String]] = settings.jsonDateTimeFields
 
+    logger.info(s"convertTimestamps: converting document ${doc.toString}")
+    logger.info(s"convertTimestamps: using jsonDateTimeFields of ${settings.jsonDateTimeFields}")
+
     val initialDoc = new Document()
     fieldSet.foreach{ parts =>
 
       def convertValue(
         remainingParts: Seq[String],
-        lastDoc: Document): Unit = {
+        lastDoc: java.util.Map[String, Object]): Unit = {
 
         val head = remainingParts.headOption
         remainingParts.size match {
           case 1 => {
             val testVal = lastDoc.get(head.get)
-            val newVal: Option[Any] = testVal match {
-              case s: String => Option(
-                Try{ OffsetDateTime.parse(s).toInstant().toEpochMilli() }.
-                toOption.
-                map{ millis => new java.util.Date(millis) }.
-                getOrElse(s)
-              )
+            val newVal: Option[Object] = testVal match {
+              case s: String => Option {
+                Try( OffsetDateTime.parse(s).toInstant().toEpochMilli() ).
+                  toOption.
+                  map { millis => new java.util.Date(millis) }.
+                  getOrElse(s)
+              }
               case i: Integer => Option(new java.util.Date(i.longValue()))
               case i: java.lang.Long => Option(new java.util.Date(i))
               case _ => None
@@ -324,16 +328,18 @@ object SinkRecordConverter {
           case n: Int if (n > 1) => {
             val testVal = lastDoc.get(head.get)
             testVal match {
-              case subDoc: Document => convertValue(remainingParts.tail, subDoc)
-              case subList: java.util.List[Document] => {
+              case subDoc: java.util.Map[String, Object] => // Document implements Map, HashMap is used sometimes too for subdocs
+                convertValue(remainingParts.tail, subDoc)
+              case subList: java.util.List[_] => {
                 subList.asScala.foreach { listDoc =>
                   listDoc match {
-                    case d: Document => convertValue(remainingParts.tail, d)
-                    case _ => // do nothing
+                    case d: java.util.Map[String, Object] =>
+                      convertValue(remainingParts.tail, d)
+                    case _ => // not a document, can't determine the name, do nothing
                   }
                 }
               }
-              case _ => // do nothing
+              case _ => // not a list or doc, can't do anything
             }
           }
           case _ => throw new Exception("somehow remainingParts is 0!")
@@ -341,5 +347,7 @@ object SinkRecordConverter {
       }
       convertValue(parts, doc)
     }
+
+    logger.debug("converted doc is: "+doc.toString)
   }
 }

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
@@ -18,9 +18,11 @@ package com.datamountaineer.streamreactor.connect.mongodb.converters
 
 import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
+import java.time.OffsetDateTime
 import java.util
 import java.util.TimeZone
 
+import com.datamountaineer.streamreactor.connect.mongodb.config.MongoSettings
 import org.apache.kafka.connect.data._
 import org.apache.kafka.connect.errors.DataException
 import org.apache.kafka.connect.sink.SinkRecord
@@ -28,7 +30,9 @@ import org.bson.Document
 import org.json4s.JValue
 import org.json4s.JsonAST._
 
+import scala.annotation.tailrec
 import scala.collection.JavaConversions._
+import scala.util.Try
 
 object SinkRecordConverter {
   private val ISO_DATE_FORMAT: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
@@ -42,7 +46,15 @@ object SinkRecordConverter {
     * @param map
     * @return
     */
-  def fromMap(map: util.Map[String, AnyRef]): Document = new Document(map)
+  def fromMap(map: util.Map[String, AnyRef])(implicit settings: MongoSettings):
+    Document = {
+
+    val doc = new Document(map)
+
+    // mutate the doc if requested before returning
+    if (settings.jsonDateTimeFields.nonEmpty) SinkRecordConverter.convertTimestamps(doc)
+    doc
+  }
 
   /**
     * Creates a Mongo document from a the Kafka Struct
@@ -227,7 +239,7 @@ object SinkRecordConverter {
     * @param record - The instance to the json node
     * @return An instance of a mongo document
     */
-  def fromJson(record: JValue): Document = {
+  def fromJson(record: JValue)(implicit settings: MongoSettings): Document = {
     def convert(name: String, jvalue: JValue, document: Document): Document = {
       def convertArray(array: JArray): util.ArrayList[Any] = {
         val list = new util.ArrayList[Any]()
@@ -264,10 +276,70 @@ object SinkRecordConverter {
       Option(value).map(document.append(name, _)).getOrElse(document)
     }
 
-    record match {
+    val doc = record match {
       case jobj: JObject =>
         jobj.obj.foldLeft(new Document) { case (d, JField(n, j)) => convert(n, j, d) }
       case _ => throw new IllegalArgumentException("Invalid json to convert to mongo ")
+    }
+
+    // mutate the doc if requested before returning
+    if (settings.jsonDateTimeFields.nonEmpty) convertTimestamps(doc)
+    doc
+  }
+
+  /**
+    * Convert timestamps based on settings' jsonDateTimeFields.
+    * @param doc
+    * @return Unit - but the input document is modified in-place!
+    */
+  def convertTimestamps(doc: Document)(implicit settings: MongoSettings): Unit = {
+
+    import scala.collection.JavaConverters._
+    val fieldSet: Set[Seq[String]] = settings.jsonDateTimeFields
+
+    val initialDoc = new Document()
+    fieldSet.foreach{ parts =>
+
+      def convertValue(
+        remainingParts: Seq[String],
+        lastDoc: Document): Unit = {
+
+        val head = remainingParts.headOption
+        remainingParts.size match {
+          case 1 => {
+            val testVal = lastDoc.get(head.get)
+            val newVal: Option[Any] = testVal match {
+              case s: String => Option(
+                Try{ OffsetDateTime.parse(s).toInstant().toEpochMilli() }.
+                toOption.
+                map{ millis => new java.util.Date(millis) }.
+                getOrElse(s)
+              )
+              case i: Integer => Option(new java.util.Date(i.longValue()))
+              case i: java.lang.Long => Option(new java.util.Date(i))
+              case _ => None
+            }
+            newVal.map{ nv => lastDoc.put(head.get, nv) }
+          }
+          case n: Int if (n > 1) => {
+            val testVal = lastDoc.get(head.get)
+            testVal match {
+              case subDoc: Document => convertValue(remainingParts.tail, subDoc)
+              case subList: java.util.List[Document] => {
+                subList.asScala.foreach { listDoc =>
+                  listDoc match {
+                    case d: Document => convertValue(remainingParts.tail, d)
+                    case _ => // do nothing
+                  }
+                }
+              }
+              case _ => // do nothing
+            }
+          }
+          case _ => throw new Exception("somehow remainingParts is 0!")
+        }
+      }
+      convertValue(parts, doc)
     }
   }
 }

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverter.scala
@@ -298,8 +298,8 @@ object SinkRecordConverter extends StrictLogging {
     import scala.collection.JavaConverters._
     val fieldSet: Set[Seq[String]] = settings.jsonDateTimeFields
 
-    logger.info(s"convertTimestamps: converting document ${doc.toString}")
-    logger.info(s"convertTimestamps: using jsonDateTimeFields of ${settings.jsonDateTimeFields}")
+    logger.debug(s"convertTimestamps: converting document ${doc.toString}")
+    logger.debug(s"convertTimestamps: using jsonDateTimeFields of ${settings.jsonDateTimeFields}")
 
     val initialDoc = new Document()
     fieldSet.foreach{ parts =>

--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractor.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractor.scala
@@ -106,6 +106,7 @@ object KeysExtractor {
               //type restriction for Mongo
               case t: BigInt => t.toLong
               case t: BigDecimal => t.toDouble
+              case t: java.util.Date => t
               case other => throw new ConfigException(s"The key $longKey is not supported for type ${Option(other).map(_.getClass.getName).getOrElse("NULL")}")
             }
           }

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/SinkRecordToDocumentTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/SinkRecordToDocumentTest.scala
@@ -82,9 +82,10 @@ class SinkRecordToDocumentTest extends WordSpec with Matchers with ConverterUtil
     }
 
     "convert Schemaless + Json payload to a Mongo Document" in {
+      // TODO: This test is exactly the same as the above test "convert String Schema + Json payload to a Mongo Document".
+      // This should probably test something different or be deleted.
       for (i <- 1 to 4) {
         val json = scala.io.Source.fromFile(getClass.getResource(s"/transaction$i.json").toURI.getPath).mkString
-
 
         val record = new SinkRecord("topic1", 0, null, null, Schema.STRING_SCHEMA, json, 0)
 

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettingsTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSettingsTest.scala
@@ -147,4 +147,46 @@ class MongoSettingsTest extends WordSpec with Matchers {
       }
     }
   }
+
+  "MongoSinkSettings.jsonDateTimeFields" should {
+
+    "default to an empty Map if not specified" in {
+      val map = Map(
+        MongoConfigConstants.DATABASE_CONFIG -> "db",
+        MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
+        MongoConfigConstants.KCQL_CONFIG -> "INSERT INTO collection1 SELECT * FROM topic1"
+      )
+      val settings = MongoSettings(MongoConfig(map))
+      settings.jsonDateTimeFields shouldBe Set.empty[List[String]]
+    }
+
+    "default to an empty Map if jsonDateTimeFields specified as empty string" in {
+      val map = Map(
+        MongoConfigConstants.DATABASE_CONFIG -> "db",
+        MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
+        MongoConfigConstants.KCQL_CONFIG -> "INSERT INTO collection1 SELECT * FROM topic1",
+        MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG -> ""
+      )
+      val settings = MongoSettings(MongoConfig(map))
+      settings.jsonDateTimeFields shouldBe Set.empty[Seq[String]]
+    }
+
+    "be set to a Set of path segments when jsonDateTimeFields is set properly" in {
+      val map = Map(
+        MongoConfigConstants.DATABASE_CONFIG -> "db",
+        MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
+        MongoConfigConstants.KCQL_CONFIG -> "INSERT INTO collection1 SELECT * FROM topic1",
+        MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG -> "a, b, c.m, d, e.n.y, f"
+      )
+      val settings = MongoSettings(MongoConfig(map))
+      settings.jsonDateTimeFields shouldBe Set(
+        List("a"),
+        List("b"),
+        List("c", "m"),
+        List("d"),
+        List("e", "n", "y"),
+        List("f")
+      )
+    }
+  }
 }

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverterTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/converters/SinkRecordConverterTest.scala
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2017 Datamountaineer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.mongodb.converters
+
+import java.time.OffsetDateTime
+import java.util
+
+import com.datamountaineer.streamreactor.connect.mongodb.config.{MongoConfig, MongoConfigConstants, MongoSettings}
+import org.scalatest.{Matchers, WordSpec}
+import org.json4s.jackson.JsonMethods._
+import org.bson.Document
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import java.util.{Map => JavaMap}
+
+class SinkRecordConverterTest extends WordSpec with Matchers {
+
+  implicit val jsonFormats = org.json4s.DefaultFormats
+  import scala.collection.JavaConverters._
+
+  // create java.util.Date from iso date string.
+  def createDate(isoDate: String): java.util.Date = {
+    val odt = OffsetDateTime.parse(isoDate)
+    new java.util.Date(odt.toInstant().toEpochMilli())
+  }
+
+  val jsonStr =
+    """{
+      |  "a": "2000-12-25T05:59:59.999Z",
+      |  "b": "2001-12-25T05:59:59.999Z",
+      |  "c": {
+      |    "m": "2002-12-25T05:59:59.999+00:00",
+      |    "n": "2003-12-25T05:59:59.999+00:00",
+      |    "o": "2004-12-25T05:59:59.999+00:00"
+      |  },
+      |  "d": "2005-12-25T05:59:59.999Z",
+      |  "e": {
+      |    "m": "2006-12-25T05:59:59.999-05:00",
+      |    "n": {
+      |      "x": "2007-12-25T05:59:59.999-05:00",
+      |      "y": "2008-12-25T05:59:59.999-05:00",
+      |      "z": "2009-12-25T05:59:59.999-05:00"
+      |    },
+      |    "o": "2010-12-25T05:59:59.999-05:00",
+      |    "p": "2010-12-25T05:59:59.999-05:00",
+      |    "q": "2010-12-25T05:59:59.999-05:00"
+      |  },
+      |  "f": "2011-12-25T05:59:59.999Z",
+      |  "g": "2012-12-25T05:59:59.999Z"
+      |}""".stripMargin
+
+  val jsonInt =
+    s"""{
+      |  "a": ${OffsetDateTime.parse("2000-12-25T05:59:59.999Z").toInstant().toEpochMilli()},
+      |  "b": ${OffsetDateTime.parse("2001-12-25T05:59:59.999Z").toInstant().toEpochMilli()},
+      |  "c": {
+      |    "m": ${OffsetDateTime.parse("2002-12-25T05:59:59.999+00:00").toInstant().toEpochMilli()},
+      |    "n": ${OffsetDateTime.parse("2003-12-25T05:59:59.999+00:00").toInstant().toEpochMilli()},
+      |    "o": ${OffsetDateTime.parse("2004-12-25T05:59:59.999+00:00").toInstant().toEpochMilli()}
+      |  },
+      |  "d": ${OffsetDateTime.parse("2005-12-25T05:59:59.999Z").toInstant().toEpochMilli()},
+      |  "e": {
+      |    "m": ${OffsetDateTime.parse("2006-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()},
+      |    "n": {
+      |      "x": ${OffsetDateTime.parse("2007-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()},
+      |      "y": ${OffsetDateTime.parse("2008-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()},
+      |      "z": ${OffsetDateTime.parse("2009-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()}
+      |    },
+      |    "o": ${OffsetDateTime.parse("2010-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()},
+      |    "p": ${OffsetDateTime.parse("2010-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()},
+      |    "q": ${OffsetDateTime.parse("2010-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()}
+      |  },
+      |  "f": ${OffsetDateTime.parse("2011-12-25T05:59:59.999Z").toInstant().toEpochMilli()},
+      |  "g": ${OffsetDateTime.parse("2012-12-25T05:59:59.999Z").toInstant().toEpochMilli()}
+      |}""".stripMargin
+
+  val baseConfig = Map(
+    MongoConfigConstants.DATABASE_CONFIG -> "db",
+    MongoConfigConstants.CONNECTION_CONFIG -> "mongodb://localhost:27017",
+    MongoConfigConstants.KCQL_CONFIG -> "INSERT INTO coll SELECT * FROM top"
+  )
+
+  "fromJson()" should {
+
+    "not modify any values for date fields when jsonDateTimeFields is NOT specified" in {
+      implicit val settings = MongoSettings(MongoConfig(baseConfig.asJava))
+      val doc: Document = SinkRecordConverter.fromJson( parse(jsonStr) )
+      val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
+
+      def check(set: Set[JavaMap.Entry[String, AnyRef]]): Unit = {
+        set.foreach{ entry => entry.getValue match {
+          case s: String => // OK
+          case dt: java.util.Date => println(s"ERROR: entry is $entry"); fail()
+          case doc: Document => check(doc.entrySet().asScala.toSet)
+          case _ => println(s"UNKNOWN TYPE ERROR: entry is $entry"); fail()
+        }}
+      }
+      check(map)
+    }
+
+    val expectedDates = Map(
+      "a"-> new java.util.Date(OffsetDateTime.parse("2000-12-25T05:59:59.999Z").toInstant().toEpochMilli()),
+      "c.n"-> new java.util.Date(OffsetDateTime.parse("2003-12-25T05:59:59.999+00:00").toInstant().toEpochMilli()),
+      "e.n.y"-> new java.util.Date(OffsetDateTime.parse("2008-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()),
+      "e.p"-> new java.util.Date(OffsetDateTime.parse("2010-12-25T05:59:59.999-05:00").toInstant().toEpochMilli()),
+      "g"-> new java.util.Date(OffsetDateTime.parse("2012-12-25T05:59:59.999Z").toInstant().toEpochMilli())
+    )
+
+    // convert strings
+    "add java.util.Date datetime values for string fields when jsonDateTimeFields are specified" in {
+      implicit val settings = MongoSettings(MongoConfig((baseConfig ++
+        Map(
+          MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG->
+            expectedDates.keySet.mkString(",")
+        )).asJava))
+      val doc: Document = SinkRecordConverter.fromJson( parse(jsonStr) )
+      val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
+
+      def check(set: Set[JavaMap.Entry[String, AnyRef]], parents: List[String] = Nil): Unit = {
+        set.foreach{ entry =>
+          val fullPath = parents :+ entry.getKey() mkString "."
+          println(s"fullPath = $fullPath")
+          entry.getValue match {
+            case s: String =>
+              expectedDates.contains(fullPath) shouldBe false
+            case dt: java.util.Date =>
+              expectedDates.get(fullPath) shouldBe Some(entry.getValue)
+            case doc: Document => check(doc.entrySet().asScala.toSet, parents:+entry.getKey)
+            case _ => { println(s"UNKNOWN TYPE ERROR: entry is $entry; parents: $parents"); fail() }
+          }
+        }
+      }
+      check(map)
+    }
+
+    // convert ints as epoch timestamps if requested
+    "add java.util.Date datetime values for Int fields when jsonDateTimeFields are specified" in {
+      println(s"jsonInt = $jsonInt")
+
+      implicit val settings = MongoSettings(MongoConfig((baseConfig ++
+        Map(
+          MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG->
+            expectedDates.keySet.mkString(",")
+        )).asJava))
+      val doc: Document = SinkRecordConverter.fromJson( parse(jsonInt) )
+      val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
+
+      def check(set: Set[JavaMap.Entry[String, AnyRef]], parents: List[String] = Nil): Unit = {
+        set.foreach{ entry =>
+          val fullPath = parents :+ entry.getKey() mkString "."
+          entry.getValue match {
+            case i: java.lang.Long =>
+              expectedDates.contains(fullPath) shouldBe false
+            case dt: java.util.Date =>
+              expectedDates.get(fullPath) shouldBe Some(entry.getValue)
+            case doc: Document =>
+              check(doc.entrySet().asScala.toSet, parents:+entry.getKey)
+            case other =>
+              println(s"UNKNOWN TYPE ERROR: other is $other; entry is $entry; parents: $parents"); fail()
+          }
+        }
+      }
+      check(map)
+    }
+
+    "create a document with String datetime values when jsonDateTimeFields are specified AND string doesn't parse to ISO8601 with Offset" in {
+      val jsonStr =
+        """{
+          |  "a": "2000-12-25T05:59:59.999",
+          |  "b": "2000-12-25T05:59:59.999+00:0",
+          |  "c": "2000-12-25T05:59:59.999-00",
+          |  "d": "2000-12-25T05:59:59.999+00:0Z",
+          |  "e": "2000-12-25T05:59:59",
+          |  "f": "2000-12-25T05:59"
+          |}""".stripMargin
+
+      implicit val settings = MongoSettings(MongoConfig((baseConfig ++
+        Map(
+          MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG->
+            "a, b, c, d, e, f"
+        )).asJava))
+      val doc: Document = SinkRecordConverter.fromJson( parse(jsonStr) )
+      val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
+
+      def check(set: Set[JavaMap.Entry[String, AnyRef]], parents: List[String] = Nil): Unit = {
+        set.foreach{ entry =>
+          val fullPath = parents :+ entry.getKey() mkString "."
+          entry.getValue match {
+            case s: String => // OK
+            case dt: java.util.Date => fail()
+            case doc: Document => check(doc.entrySet().asScala.toSet, parents:+entry.getKey)
+            case _ => println(s"UNKNOWN TYPE ERROR: entry is $entry; parents: $parents"); fail()
+          }
+        }
+      }
+      check(map)
+    }
+
+    "dig out timestamps in arrays if they are named" in {
+      // All 'ts' values should be converted:
+      val json =
+        """{
+          |  "b": "2000-12-25T05:59:59.999Z",
+          |  "c": [
+          |    { "ts": "2002-12-25T05:59:59.999+00:00"},
+          |    { "ts": "2002-12-25T05:59:59.999+00:00",  "nts": "2002-12-25T05:59:59.999+00:00"},
+          |    { "nts": "2002-12-25T05:59:59.999+00:00",  "ts": "2002-12-25T05:59:59.999+00:00"}
+          |  ],
+          |  "d": "2005-12-25T05:59:59.999Z",
+          |  "e": [
+          |    { "m": { "nts": "2002-12-25T05:59:59.999+00:00" } },
+          |    { "n": [
+          |      { "x": { "nts": "2002-12-25T05:59:59.999+00:00", "ts": "2002-12-25T05:59:59.999+00:00"}},
+          |      { "nts": "2002-12-25T05:59:59.999+00:00", "nts2": "2002-12-25T05:59:59.999+00:00"}
+          |    ]},
+          |    { "o": { "nts": "2002-12-25T05:59:59.999+00:00" } }
+          |  ]
+          |}""".stripMargin
+
+      implicit val settings = MongoSettings(MongoConfig((baseConfig ++
+        Map(
+          MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG->
+            "c.ts, e.n.x.ts"
+        )).asJava))
+      val doc: Document = SinkRecordConverter.fromJson( parse(json) )
+      val map: Set[JavaMap.Entry[String, AnyRef]] = doc.entrySet().asScala.toSet
+
+      def check(
+        set: Set[JavaMap.Entry[String, AnyRef]],
+        parents: List[String] = Nil): Unit = {
+
+        set.foreach{ entry =>
+          val fullPath = parents :+ entry.getKey() mkString "."
+          val key = entry.getKey
+          val value = entry.getValue
+          value match {
+            case s: String => key should not be ("ts")
+            case dt: java.util.Date => key should be ("ts")
+            case array: java.util.ArrayList[_] =>
+              val list = array.asScala.toList
+              list.foreach{ d =>
+                d match {
+                  case doc: Document =>
+                    check(doc.entrySet().asScala.toSet, parents :+ key)
+                  case _ => fail() // expect Document types
+                }
+              }
+            case doc: Document => {
+              check(doc.entrySet().asScala.toSet, parents:+entry.getKey)
+            }
+            case _ => println(s"UNKNOWN TYPE ERROR: entry is $entry; parents: $parents"); fail()
+          }
+        }
+      }
+      check(map)
+    }
+    
+  }
+
+  "fromMap()" should {
+
+    "convert timestamps if requested" in {
+
+      // This isn't a very thorough test.  See other tests for
+      // subdocument and sublist handling tests.
+      // Todo move the json tests under convertTimestamps() and
+      // simplify the json tests like this one.
+      val map = Map[String, AnyRef](
+        "A" -> new Integer(10),
+        "B" -> new Document( Map[String, Object](
+            "M" -> "2009-12-25T05:59:59.999-05:00",
+            "N" -> "2009-12-25T05:59:59.999-05:00"
+          ).asJava
+        )
+      ).asJava
+
+      implicit val settings = MongoSettings(MongoConfig((baseConfig ++
+        Map(
+          MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG->
+            "A, B.N"
+        )).asJava))
+
+      val doc = SinkRecordConverter.fromMap(map)
+
+      import java.util.Date
+      doc.get("A").asInstanceOf[Date] shouldBe (new Date(10))
+      val b = doc.get("B").asInstanceOf[Document]
+      b.getString("M") shouldBe "2009-12-25T05:59:59.999-05:00"
+      b.get("N").asInstanceOf[Date] shouldBe createDate("2009-12-25T05:59:59.999-05:00")
+    }
+  }
+
+
+  "convertTimestamps()" should {
+
+    "convert int and string values in Documents" in {
+
+      import java.util.LinkedList
+
+      // create the test doc
+      val map = new java.util.HashMap[String, Object]()
+      map.put("A", "0")
+      val subMap = new java.util.HashMap[String, Object]()
+      subMap.put("M", "1")
+      subMap.put("N", new java.lang.Integer(2))
+      val subDoc = new Document(subMap)
+      map.put("subDoc", subDoc)
+
+      val subList = new LinkedList[Document]()
+      val xDoc = new Document()
+      xDoc.put("X", 100)
+      xDoc.put("Y", 101)
+      val yDoc = new Document()
+      yDoc.put("Y", 102)
+      subList.add(xDoc)
+      subList.add(yDoc)
+      map.put("subList", subList)
+
+      map.put("timestamp", "2009-12-25T05:59:59.999+00:00")
+
+      val doc = new Document(map)
+
+      implicit val settings = MongoSettings(MongoConfig((baseConfig ++
+        Map(
+          MongoConfigConstants.JSON_DATETIME_FIELDS_CONFIG->
+            "subDoc.N, timestamp, subList.Y"
+        )).asJava))
+
+      println("map is "+map)
+      //map is {A=0, subList=[Document{{X=100, Y=101}}, Document{{Y=102}}],
+      // subDoc=Document{{M=1, N=2}}, timestamp=2009-12-25T05:59:59.999+00:00}
+
+      SinkRecordConverter.convertTimestamps(doc)
+
+      doc.getString("A") shouldBe "0"
+      val expectedSubList = {
+        val newX = new Document()
+        newX.put("X", 100)
+        newX.put("Y", new java.util.Date(101))
+
+        val newY = new Document()
+        newY.put("Y", new java.util.Date(102))
+        List(newX, newY)
+      }
+      val actualSubList = doc.get("subList").asInstanceOf[LinkedList[Document]].asScala.toList
+      actualSubList(0).entrySet shouldBe expectedSubList(0).entrySet
+      actualSubList(1).entrySet shouldBe expectedSubList(1).entrySet
+      actualSubList.size shouldBe expectedSubList.size
+
+      doc.get("timestamp") shouldBe createDate("2009-12-25T05:59:59.999+00:00")
+
+      val sd = doc.get("subDoc").asInstanceOf[Document]
+      sd.getString("M") shouldBe "1"
+      sd.get("N") shouldBe (new java.util.Date(2))
+    }
+  }
+
+}
+

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/sink/KeysExtractorTest.scala
@@ -69,14 +69,14 @@ class KeysExtractorTest extends WordSpec with Matchers {
       actual shouldBe Set("key1" -> 12, "key3" -> "tripple")
     }
 
-    "extract embedded keys out of a Map" in {
+    "extract embedded keys out of a Map (including Dates)" in {
       import scala.collection.JavaConverters._
       val actual = KeysExtractor.fromMap(
-        Map("A"->0, "B"->"0", "C"->Map("M"->"1000", "N"->Map("X"->10, "Y"->100).asJava).asJava).asJava,
+        Map("A"->0, "B"->"0", "C"->Map("M"->"1000", "N"->Map("X"->new java.util.Date(10L), "Y"->100).asJava).asJava).asJava,
         ListSet( "B", "C.M", "C.N.X" ))
       // SCALA 2.12 WARNING: If you upgrade to 2.12 and this test fails, 
       // you need to remove the "reverse()" calls in KeysExtractor.scala:
-      actual shouldBe ListSet("B"->"0", "M"->"1000", "X"->10)
+      actual shouldBe ListSet("B"->"0", "M"->"1000", "X"->new java.util.Date(10L))
     }
 
     "extract keys from a Map should throw an exception if the key is another map" in {


### PR DESCRIPTION
For sinking JSON messages to mongodb, this adds the ability to configure a list of fields that should 
be converted to ISODate on insertion.  Without this patch, the 
fields are added as strings, which can be problematic when dealing with 
time offsets.

New configuration field is: 

connect.mongo.json_datetime_fields.

Description (added to documentation):

List of fields that should be converted to ISODate on Mongodb insertion 
(comma-separated field names).  For JSON topics only.  Field values may be 
an integral epoch time or an ISO8601 datetime string with an offset (offset 
or 'Z' required).  If string does not parse to ISO, it will be written as a 
string instead.
Subdocument fields can be referred to as in the following examples: 
  "topLevelFieldName",
  "topLevelSubDocument.FieldName",
  "topLevelParent.subDocument.subDocument2.FieldName", (etc.)
If a field is converted to ISODate and that same field is named as a PK, then
the PK field is also written as an ISODate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/496)
<!-- Reviewable:end -->
