### PR TITLE
fix bug: creating kudu table multiple times

### DIFF
--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
@@ -97,24 +97,23 @@ object DbHandler extends StrictLogging with KuduConverter {
     val url = setting.schemaRegistryUrl
     val subjects = SchemaRegistry.getSubjects(url).toSet
 
-    subjects
-      .flatMap(_ => {
-        setting
-          .kcql
-          .filter(r => r.isAutoCreate && !client.tableExists(r.getTarget)) //don't try to create existing tables
-          .map(m => {
-          var lkTopic = m.getSource
+    setting
+      .kcql
+      .filter(r => r.isAutoCreate && !client.tableExists(r.getTarget)) //don't try to create existing tables
+      .map(m => {
+        var lkTopic = m.getSource
 
-          if (!subjects.contains(lkTopic)) {
-            if (subjects.contains(lkTopic + "-value")) {
-              lkTopic = lkTopic + "-value"
-            }
+        if (!subjects.contains(lkTopic)) {
+          if (subjects.contains(lkTopic + "-value")) {
+            lkTopic = lkTopic + "-value"
           }
+        }
 
-          createTableProps(SchemaRegistry.getSchema(url, lkTopic), m, url, client)
-        })
-      }).flatten
+        createTableProps(SchemaRegistry.getSchema(url, lkTopic), m, url, client)
+      })
+      .flatten
       .map(ctp => executeCreateTable(ctp, client))
+      .toSet
   }
 
   /**


### PR DESCRIPTION
in `com.datamountaineer.streamreactor.connect.kudu.sink.DbHandler`:createTables, there is no need for the outer loop on `subjects`. And the loop on `subjects` will lead to creating same table multiple times, which will be failed for the second time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/510)
<!-- Reviewable:end -->
