### PR TITLE
Support for Cassandra password file

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/CassandraConnection.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/CassandraConnection.scala
@@ -79,8 +79,8 @@ object CassandraConnection extends StrictLogging {
 
     val password = {
       if (connectorConfig.originals().containsKey(CassandraConfigConstants.PASSWD_FILE)) {
-        val passwordFile = connectorConfig.getString(CassandraConfigConstants.PASSWD_FILE)
-        Source.fromFile(passwordFile).getLines.mkString
+        val passwordFile = connectorConfig.getPassword(CassandraConfigConstants.PASSWD_FILE)
+        Source.fromFile(passwordFile.value).getLines.mkString
       }
       else
         connectorConfig.getPassword(CassandraConfigConstants.PASSWD).value

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -169,6 +169,15 @@ case class CassandraConfig() {
       ConfigDef.Width.MEDIUM,
       CassandraConfigConstants.CONSISTENCY_LEVEL_DISPLAY)
 
+    .define(CassandraConfigConstants.PASSWD_FILE,
+      Type.STRING, "",
+      Importance.LOW,
+      CassandraConfigConstants.PASSWD_FILE_DOC,
+      "Connection",
+      15,
+      ConfigDef.Width.LONG,
+      CassandraConfigConstants.PASSWD_FILE)
+
     .define(CassandraConfigConstants.ERROR_POLICY,
       Type.STRING,
       CassandraConfigConstants.ERROR_POLICY_DEFAULT,

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -170,7 +170,7 @@ case class CassandraConfig() {
       CassandraConfigConstants.CONSISTENCY_LEVEL_DISPLAY)
 
     .define(CassandraConfigConstants.PASSWD_FILE,
-      Type.STRING, "",
+      Type.PASSWORD, "",
       Importance.LOW,
       CassandraConfigConstants.PASSWD_FILE_DOC,
       "Connection",

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -56,6 +56,9 @@ object CassandraConfigConstants {
   val USERNAME_DOC = "Username to connect to Cassandra with."
   val USERNAME_DEFAULT = "cassandra.cassandra"
 
+  val PASSWD_FILE = s"$CONNECTOR_PREFIX.$PASSWORD_SUFFIX.file"
+  val PASSWD_FILE_DOC = "File containing the password for the username to connect to Cassandra with."
+
   val PASSWD = s"$CONNECTOR_PREFIX.$PASSWORD_SUFFIX"
   val PASSWD_DOC = "Password for the username to connect to Cassandra with."
   val PASSWD_DEFAULT = "cassandra"


### PR DESCRIPTION
For security/infrastructure reasons we've opted for using password files rather than providing passwords as strings. This implementation is fairly straightforward, though it does prefer using a password file if both are provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/515)
<!-- Reviewable:end -->
