### PR TITLE
fix (kafka-connect-redis): Added support for custom delimeter on the …

### DIFF
--- a/conf/redis-sink.properties
+++ b/conf/redis-sink.properties
@@ -21,3 +21,4 @@ connect.redis.host=localhost
 connect.redis.port=6379
 connect.redis.kcql=INSERT INTO TABLE1 SELECT * FROM redis-topic
 connect.progress.enabled=true
+connect.redis.pk.delimiter=.

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisConfig.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisConfig.scala
@@ -43,8 +43,11 @@ object RedisConfig {
       Importance.MEDIUM, RedisConfigConstants.NBR_OF_RETRIES_DOC,
       "Connection", 7, ConfigDef.Width.MEDIUM, RedisConfigConstants.NBR_OF_RETRIES)
     .define(RedisConfigConstants.PROGRESS_COUNTER_ENABLED, Type.BOOLEAN, RedisConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
-        Importance.MEDIUM, RedisConfigConstants.PROGRESS_COUNTER_ENABLED_DOC,
-        "Metrics", 1, ConfigDef.Width.MEDIUM, RedisConfigConstants.PROGRESS_COUNTER_ENABLED_DISPLAY)
+      Importance.MEDIUM, RedisConfigConstants.PROGRESS_COUNTER_ENABLED_DOC,
+      "Metrics", 1, ConfigDef.Width.MEDIUM, RedisConfigConstants.PROGRESS_COUNTER_ENABLED_DISPLAY)
+    .define(RedisConfigConstants.REDIS_PK_DELIMITER, Type.STRING,
+      RedisConfigConstants.REDIS_PK_DELIMITER_DEFAULT_VALUE,
+      Importance.LOW, RedisConfigConstants.REDIS_PK_DELIMITER_DOC)
 }
 
 /**

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisConfigConstants.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisConfigConstants.scala
@@ -22,7 +22,7 @@ import com.datamountaineer.streamreactor.connect.config.base.const.TraitConfigCo
 object RedisConfigConstants {
 
   val CONNECTOR_PREFIX = "connect.redis"
-  
+
   val REDIS_HOST = s"${CONNECTOR_PREFIX}.${CONNECTION_HOST_SUFFIX}"
   private[config] val REDIS_HOST_DOC: String =
     """
@@ -66,4 +66,11 @@ object RedisConfigConstants {
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
+
+  val REDIS_PK_DELIMITER = s"${CONNECTOR_PREFIX}.pk.delimiter"
+  private[config] val REDIS_PK_DELIMITER_DOC: String =
+    """
+      |Specifies the redis primary key delimiter
+    """.stripMargin
+  val REDIS_PK_DELIMITER_DEFAULT_VALUE = "."
 }

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
@@ -35,6 +35,7 @@ case class RedisKCQLSetting(topic: String,
 
 // All the settings of the running connector
 case class RedisSinkSettings(connectionInfo: RedisConnectionInfo,
+                             pkDelimiter: String,
                              kcqlSettings: Set[RedisKCQLSetting],
                              errorPolicy: ErrorPolicy = new ThrowErrorPolicy,
                              taskRetries: Int = RedisConfigConstants.NBR_OF_RETIRES_DEFAULT)
@@ -58,6 +59,8 @@ object RedisSinkSettings {
     // Get connection info
     val connectionInfo = RedisConnectionInfo(config)
 
+    val pkDelimiter = config.getString(RedisConfigConstants.REDIS_PK_DELIMITER)
+
     // Get the builders
     val builders = config.getRowKeyBuilders()
 
@@ -73,7 +76,7 @@ object RedisSinkSettings {
       )
     }.toSet
 
-    RedisSinkSettings(connectionInfo, allRedisKCQLSettings, errorPolicy, nbrOfRetries)
+    RedisSinkSettings(connectionInfo, pkDelimiter, allRedisKCQLSettings, errorPolicy, nbrOfRetries)
   }
 
 }

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCache.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCache.scala
@@ -69,7 +69,8 @@ class RedisCache(sinkSettings: RedisSinkSettings) extends RedisWriter {
                 // We can prefix the name of the <KEY> using the target
                 val optionalPrefix = if (Option(KCQL.kcqlConfig.getTarget).isEmpty) "" else KCQL.kcqlConfig.getTarget.trim
                 // Use first primary key's value and (optional) prefix
-                val keyBuilder = RedisFieldsKeyBuilder(KCQL.kcqlConfig.getPrimaryKeys.map(_.toString))
+                val pkDelimiter = sinkSettings.pkDelimiter
+                val keyBuilder = RedisFieldsKeyBuilder(KCQL.kcqlConfig.getPrimaryKeys.map(_.toString), pkDelimiter)
                 val extracted = convert(record, fields = KCQL.fieldsAndAliases, ignoreFields = KCQL.ignoredFields)
                 val key = optionalPrefix + keyBuilder.build(record)
                 val payload = convertValueToJson(extracted).toString

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisFieldsKeyBuilder.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisFieldsKeyBuilder.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConversions._
   *
   * @param keys The key to build
   */
-case class RedisFieldsKeyBuilder(keys: Seq[String]) extends StringKeyBuilder {
+case class RedisFieldsKeyBuilder(keys: Seq[String], pkDelimiter: String) extends StringKeyBuilder {
   require(keys.nonEmpty, "Keys are empty")
 
   /**
@@ -50,11 +50,13 @@ case class RedisFieldsKeyBuilder(keys: Seq[String]) extends StringKeyBuilder {
           case (v, _) => Option(v)
         }
 
-      findValue(key.split('.').toList, struct).getOrElse { throw new IllegalArgumentException(
-        s"$key field value is null. Non null value is required for the fields creating the row key"
-      )}
+      findValue(key.split('.').toList, struct).getOrElse {
+        throw new IllegalArgumentException(
+          s"$key field value is null. Non null value is required for the fields creating the row key"
+        )
+      }
     }
 
-    keys.map(getValue).mkString(".")
+    keys.map(getValue).mkString(pkDelimiter)
   }
 }

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/ConfigMultipleSortedSetsTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/ConfigMultipleSortedSetsTest.scala
@@ -87,7 +87,7 @@ class ConfigMultipleSortedSetsTest extends WordSpec with Matchers with RedisMock
     val route = settings.kcqlSettings.head.kcqlConfig
     val fields = route.getFields.asScala.toList
 
-    route.getPrimaryKeys.asScala.head .getName shouldBe "sensorID"
+    route.getPrimaryKeys.asScala.head.getName shouldBe "sensorID"
     route.getFields.asScala.exists(_.getName.equals("*")) shouldBe false
     route.getSource shouldBe "sensorsTopic"
     route.getStoredAs shouldBe "SortedSet"

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisConfigTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisConfigTest.scala
@@ -31,6 +31,10 @@ class RedisConfigTest extends WordSpec with Matchers {
       RedisConfig.config.parse(propsWithoutPass + (RedisConfigConstants.REDIS_PASSWORD -> "pass"))
     }
 
+    "use custom delimiter for primary key" in {
+      RedisConfig.config.parse(propsWithoutPass + (RedisConfigConstants.REDIS_PK_DELIMITER -> "-"))
+    }
+
   }
 
   val propsWithoutPass = Map(RedisConfigConstants.REDIS_HOST -> "localhost",

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
@@ -36,6 +36,19 @@ class RedisSinkSettingsTest extends WordSpec with Matchers with RedisMockSupport
     settings.connectionInfo.password shouldBe None
   }
 
+  "default primary key delimiter" in {
+    val KCQL = "SELECT * FROM topicA PK lastName"
+    val settings = RedisSinkSettings(getRedisSinkConfig(password = false, KCQL = Option(KCQL)))
+    settings.pkDelimiter shouldBe RedisConfigConstants.REDIS_PK_DELIMITER_DEFAULT_VALUE
+  }
+
+  "custom primary key delimiter" in {
+    val delimiter = "-"
+    val KCQL = "SELECT * FROM topicA PK lastName"
+    val settings = RedisSinkSettings(getRedisSinkConfig(password = false, KCQL = Option(KCQL), pkDelimiter = Option(delimiter)))
+    settings.pkDelimiter shouldBe delimiter
+  }
+
   "should throw an expection as no PK set in Cache Mode : SELECT * FROM topicA" in {
     val QUERY_ALL = "SELECT * FROM topicA"
     val config = getRedisSinkConfig(password = true, KCQL = Option(QUERY_ALL))

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/support/RedisMockSupport.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/support/RedisMockSupport.scala
@@ -24,19 +24,24 @@ import scala.collection.JavaConverters._
 
 trait RedisMockSupport extends MockitoSugar {
 
-  def getRedisSinkConfig(password: Boolean, KCQL: Option[String]) = {
+  def getRedisSinkConfig(password: Boolean, KCQL: Option[String], pkDelimiter: Option[String] = None) = {
 
     var baseProps = scala.collection.mutable.Map[String, String]()
-    baseProps += (RedisConfigConstants.REDIS_HOST->"localhost", RedisConfigConstants.REDIS_PORT->"8453")
+    baseProps += (RedisConfigConstants.REDIS_HOST -> "localhost", RedisConfigConstants.REDIS_PORT -> "8453")
 
 
     if (password) {
-      baseProps += RedisConfigConstants.REDIS_PASSWORD->"secret"
+      baseProps += RedisConfigConstants.REDIS_PASSWORD -> "secret"
     }
 
-    if (KCQL.isDefined) {
-      baseProps += RedisConfigConstants.KCQL_CONFIG->KCQL.get
+    KCQL.foreach { kcql =>
+      baseProps += RedisConfigConstants.KCQL_CONFIG -> kcql
     }
+
+    pkDelimiter.foreach { delimiter =>
+      baseProps += RedisConfigConstants.REDIS_PK_DELIMITER -> delimiter
+    }
+
     RedisConfig(baseProps.asJava)
   }
 

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCacheTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCacheTest.scala
@@ -39,6 +39,7 @@ class RedisCacheTest extends WordSpec with Matchers with BeforeAndAfterAll with 
   )
 
   override def beforeAll() = redisServer.start()
+
   override def afterAll() = redisServer.stop()
 
   "RedisDbWriter" should {
@@ -166,6 +167,78 @@ class RedisCacheTest extends WordSpec with Matchers with BeforeAndAfterAll with 
       map2("firstName") shouldBe "Mara"
       map2("age").toString shouldBe "22.0"
       map2("threshold").toString shouldBe "12.4"
+    }
+  }
+
+  "RedisDbWriter" should {
+
+    val QUERY_ALL = s"SELECT * FROM $TOPIC PK firstName, child.firstName"
+    val base_Props = baseProps + (RedisConfigConstants.KCQL_CONFIG -> QUERY_ALL)
+
+    val childSchema = SchemaBuilder.struct().name("com.example.Child")
+      .field("firstName", Schema.STRING_SCHEMA)
+      .build()
+
+    val schema = SchemaBuilder.struct().name("com.example.Person")
+      .field("firstName", Schema.STRING_SCHEMA)
+      .field("age", Schema.INT32_SCHEMA)
+      .field("child", childSchema)
+      .build()
+
+    val nickJr = new Struct(childSchema)
+      .put("firstName", "Nick_Junior")
+    val nick = new Struct(schema)
+      .put("firstName", "Nick")
+      .put("age", 30)
+      .put("child", nickJr)
+
+    val nickRecord = new SinkRecord(TOPIC, 1, null, null, schema, nick, 0)
+
+    "write Kafka records to Redis using CACHE mode and PK has default delimiter" in {
+
+      val props = (base_Props).asJava
+      val config = RedisConfig(props)
+      val settings = RedisSinkSettings(config)
+      val writer = new RedisCache(settings)
+
+      writer.write(Seq(nickRecord))
+
+      val key = nick.get("firstName") + RedisConfigConstants.REDIS_PK_DELIMITER_DEFAULT_VALUE + nickJr.get("firstName")
+      val nickValue = jedis.get(key)
+      key shouldBe ("Nick.Nick_Junior")
+      nickValue should not be null
+    }
+
+    "write Kafka records to Redis using CACHE mode and PK has custom delimiter" in {
+
+      val delimiter = "-"
+      val props = (base_Props + (RedisConfigConstants.REDIS_PK_DELIMITER -> delimiter)).asJava
+      val config = RedisConfig(props)
+      val settings = RedisSinkSettings(config)
+      val writer = new RedisCache(settings)
+
+      writer.write(Seq(nickRecord))
+
+      val key = nick.get("firstName") + delimiter + nickJr.get("firstName")
+      val nickValue = jedis.get(key)
+      key shouldBe ("Nick-Nick_Junior")
+      nickValue should not be null
+    }
+
+    "write Kafka records to Redis using CACHE mode and PK has custom delimiter but not set" in {
+
+      val delimiter = "$"
+      val props = (base_Props).asJava
+      val config = RedisConfig(props)
+      val settings = RedisSinkSettings(config)
+      val writer = new RedisCache(settings)
+
+      writer.write(Seq(nickRecord))
+
+      val key = nick.get("firstName") + delimiter + nickJr.get("firstName")
+      val nickValue = jedis.get(key)
+      key shouldBe ("Nick$Nick_Junior")
+      nickValue shouldBe null
     }
   }
 }


### PR DESCRIPTION
…REDIS sink

	- added new configuration : connect.redis.pk.delimiter with a default value of "."
	- the composite keys are using the value defined by connect.redis.pk.delimiter
	- Added unit tests

Fixes #499

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/517)
<!-- Reviewable:end -->
