### PR TITLE
Support array type in InfluxDB connector

### DIFF
--- a/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/writers/ValuesExtractor.scala
+++ b/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/writers/ValuesExtractor.scala
@@ -219,7 +219,8 @@ object ValuesExtractor {
                  Schema.Type.INT16 |
                  Schema.Type.INT32 |
                  Schema.Type.INT64 |
-                 Schema.Type.STRING => value
+                 Schema.Type.STRING |
+                 Schema.Type.ARRAY => value
 
             case other =>
               throw new IllegalArgumentException(s"You can't select * from the Kafka Message. Field:'${field.name()}' resolves to a Schema '$other' which will end up with a type not supported by InfluxDB API.")
@@ -278,7 +279,8 @@ object ValuesExtractor {
                  Schema.Type.INT16 |
                  Schema.Type.INT32 |
                  Schema.Type.INT64 |
-                 Schema.Type.STRING => value
+                 Schema.Type.STRING |
+                 Schema.Type.ARRAY => value
 
             case other =>
               throw new IllegalArgumentException(s"You can't select * from the Kafka Message. Field:'${field.name()}' resolves to a Schema '$other' which will end up with a type not supported by InfluxDB API.")


### PR DESCRIPTION
- InfluxDB does not support arrays so we extract each element of
the array and write them as new fields in InfluxDB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/522)
<!-- Reviewable:end -->
