### PR TITLE
Adds ttl support to redis

### DIFF
--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCache.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisCache.scala
@@ -74,7 +74,12 @@ class RedisCache(sinkSettings: RedisSinkSettings) extends RedisWriter {
                 val extracted = convert(record, fields = KCQL.fieldsAndAliases, ignoreFields = KCQL.ignoredFields)
                 val key = optionalPrefix + keyBuilder.build(record)
                 val payload = convertValueToJson(extracted).toString
-                jedis.set(key, payload)
+                val ttl = KCQL.kcqlConfig.getTTL
+                if (ttl <= 0) {
+                  jedis.set(key, payload)
+                } else {
+                  jedis.setex(key, ttl.toInt, payload)
+                }
               }
             }
           })

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisInsertSortedSet.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisInsertSortedSet.scala
@@ -84,9 +84,13 @@ class RedisInsertSortedSet(sinkSettings: RedisSinkSettings) extends RedisWriter 
               logger.debug(s"ZADD $sortedSetName    score = $score     payload = ${payload.toString}")
               val response = jedis.zadd(sortedSetName, score, payload.toString)
 
-              if (response == 1)
+              if (response == 1) {
                 logger.debug("New element added")
-              else if (response == 0)
+                val ttl = KCQL.kcqlConfig.getTTL
+                if (ttl > 0) {
+                  jedis.expire(sortedSetName, ttl.toInt)
+                }
+              } else if (response == 0)
                 logger.debug("The element was already a member of the sorted set and the score was updated")
               response
             }

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisMultipleSortedSets.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisMultipleSortedSets.scala
@@ -86,9 +86,13 @@ class RedisMultipleSortedSets(sinkSettings: RedisSinkSettings) extends RedisWrit
               logger.debug(s"ZADD $sortedSetName    score = $score     payload = ${payload.toString}")
               val response = jedis.zadd(sortedSetName, score, payload.toString)
 
-              if (response == 1)
+              if (response == 1) {
                 logger.debug("New element added")
-              else if (response == 0)
+                val ttl = KCQL.kcqlConfig.getTTL
+                if (ttl > 0) {
+                  jedis.expire(sortedSetName, ttl.toInt)
+                }
+              } else if (response == 0)
                 logger.debug("The element was already a member of the sorted set and the score was updated")
               response
             }


### PR DESCRIPTION
It is crucial in my use case for Redis keys to have TTL, so I add it.
I'm not sure if it is the right way or not. but please merge it if it is.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/541)
<!-- Reviewable:end -->
