### PR TITLE
Fix JMS messages containing null values in properties

### DIFF
--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/domain/JMSStructMessage.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/domain/JMSStructMessage.scala
@@ -47,7 +47,7 @@ import scala.collection.JavaConversions._
           .field("type", Schema.OPTIONAL_STRING_SCHEMA)
           .field("priority", Schema.OPTIONAL_INT32_SCHEMA)
           .field("bytes_payload", Schema.OPTIONAL_BYTES_SCHEMA)
-          .field("properties", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional())
+          .field("properties", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).optional())
           .build()
       }
 


### PR DESCRIPTION
Oracle Advanced Queues are sending JMS messages where some properties have null values. This pull request adds support for this behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/551)
<!-- Reviewable:end -->
