### PR TITLE
Fixes the comparison for Cassandra timestamp type during connector setup

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -103,7 +103,7 @@ object CassandraSettings extends StrictLogging {
         case _ => TimestampType.NONE
       }
 
-      if (tCols.size != 1 && TimestampType.equals(TimestampType.NONE)) {
+      if (tCols.size != 1 && timestampType.equals(TimestampType.NONE)) {
         throw new ConfigException("Only one primary key column is allowed to be specified in Incremental mode. " +
           s"Received ${tCols.mkString(",")} for source ${r.getSource}")
       }
@@ -111,7 +111,7 @@ object CassandraSettings extends StrictLogging {
       CassandraSourceSetting(
         kcql = r,
         keySpace = keySpace,
-        primaryKeyColumn = if (tCols.isEmpty) None else Some(tCols.head),
+        primaryKeyColumn = tCols.headOption,
         timestampColType = timestampType,
         pollInterval = pollInterval,
         errorPolicy = errorPolicy,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/561)
<!-- Reviewable:end -->
