### PR TITLE
Custom Static JMS headers support

### DIFF
--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
@@ -71,6 +71,9 @@ object JMSConfig {
     .define(JMSConfigConstants.AVRO_CONVERTERS_SCHEMA_FILES, Type.STRING, JMSConfigConstants.AVRO_CONVERTERS_SCHEMA_FILES_DEFAULT,
         Importance.HIGH, JMSConfigConstants.AVRO_CONVERTERS_SCHEMA_FILES_DOC, "Converter", 3, ConfigDef.Width.MEDIUM,
         JMSConfigConstants.AVRO_CONVERTERS_SCHEMA_FILES)
+    .define(JMSConfigConstants.HEADERS_CONFIG,
+      Type.STRING, "", Importance.LOW, JMSConfigConstants.HEADERS_CONFIG_DOC,
+      "Converter", 4, ConfigDef.Width.MEDIUM, JMSConfigConstants.HEADERS_CONFIG_DISPLAY)
 
     .define(JMSConfigConstants.PROGRESS_COUNTER_ENABLED, Type.BOOLEAN, JMSConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
         Importance.MEDIUM, JMSConfigConstants.PROGRESS_COUNTER_ENABLED_DOC,

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
@@ -74,6 +74,14 @@ object JMSConfigConstants {
   private[config] val DEFAULT_CONVERTER_DISPLAY = "Default Converter class"
 
 
+  val HEADERS_CONFIG = s"${CONNECTOR_PREFIX}.headers"
+  private[config] val HEADERS_CONFIG_DOC =
+    s"""
+      |Contains collection of static JMS headers included in every SinkRecord
+      |The format is ${CONNECTOR_PREFIX}.headers="$$MQTT_TOPIC=rmq.jms.message.type:TextMessage,rmq.jms.message.priority:2;$$MQTT_TOPIC2=rmq.jms.message.type:JSONMessage"""".stripMargin
+  private[config] val HEADERS_CONFIG_DISPLAY = "JMS static headers"
+
+
   val THROW_ON_CONVERT_ERRORS_CONFIG = s"${CONNECTOR_PREFIX}.converter.throw.on.error"
   private[config] val THROW_ON_CONVERT_ERRORS_DOC = "If set to false the conversion exception will be swallowed and everything carries on BUT the message is lost!!; true will throw the exception.Default is false."
   private[config] val THROW_ON_CONVERT_ERRORS_DISPLAY = "Throw error on conversion"

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/converters/JMSHeadersConverterWrapper.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/converters/JMSHeadersConverterWrapper.scala
@@ -1,0 +1,24 @@
+package com.datamountaineer.streamreactor.connect.jms.sink.converters
+import com.datamountaineer.streamreactor.connect.jms.config.JMSSetting
+import javax.jms.{Message, Session}
+import org.apache.kafka.connect.sink.SinkRecord
+
+
+class JMSHeadersConverterWrapper(headers: Map[String, String], delegate: JMSMessageConverter) extends JMSMessageConverter {
+
+
+  override def convert(record: SinkRecord, session: Session, setting: JMSSetting): (String, Message) = {
+    val response = delegate.convert(record, session, setting)
+    val message = response._2
+    for((key, value) <- headers) {
+      message.setObjectProperty(key, value)
+    }
+    response
+  }
+}
+
+
+object JMSHeadersConverterWrapper {
+  def apply(config: Map[String, String], delegate: JMSMessageConverter): JMSMessageConverter =
+    new JMSHeadersConverterWrapper(config, delegate)
+}

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
@@ -21,16 +21,13 @@ import java.net.ServerSocket
 import java.nio.file.Paths
 import java.util
 import java.util.UUID
-import javax.jms.{BytesMessage, Connection, Session, TextMessage}
 
-import com.datamountaineer.streamreactor.connect.converters.source.AvroConverter
 import com.datamountaineer.streamreactor.connect.jms.config.{DestinationSelector, JMSConfigConstants}
 import com.sksamuel.avro4s.{AvroOutputStream, SchemaFor}
+import javax.jms.{BytesMessage, Connection, Session, TextMessage}
 import org.apache.activemq.ActiveMQConnectionFactory
-import org.apache.activemq.broker.{BrokerService, ConnectionContext}
-import org.apache.activemq.command.Message
+import org.apache.activemq.broker.BrokerService
 import org.apache.activemq.jndi.ActiveMQInitialContextFactory
-import org.apache.activemq.security.MessageAuthorizationPolicy
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
 import org.scalatest.mockito.MockitoSugar
@@ -72,8 +69,9 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
     schemaFile.toAbsolutePath.toString
   }
 
-  def getSinkProps(kcql: String, topics: String, url: String): util.Map[String, String] = {
-    (Map("topics" -> topics) ++ getProps(kcql, url)).asJava
+  def getSinkProps(kcql: String, topics: String,
+                   url: String, customProperties: Map[String, String] = Map()): util.Map[String, String] = {
+    (Map("topics" -> topics) ++ getProps(kcql, url) ++ customProperties).asJava
   }
 
   def getProps(kcql: String, url: String): Map[String, String] = {


### PR DESCRIPTION
New configuration option `connect.jms.headers` to define custom static JMS
headers (`JMSType`, `JMSExpirationTime`, `JMSPriority`, `ReplyTo` etc.) for each JMS destination.
Parameter is optional so connector configuration is backward compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/576)
<!-- Reviewable:end -->
