### PR TITLE
Featrue/fix cannot add columns

### DIFF
--- a/kafka-connect-kudu/build.gradle
+++ b/kafka-connect-kudu/build.gradle
@@ -16,7 +16,7 @@
 
 project(":kafka-connect-kudu") {
     ext {
-        kuduVersion = "1.7.0"
+        kuduVersion = "1.8.0"
     }
 
     dependencies {

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/KuduConverter.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/KuduConverter.scala
@@ -229,8 +229,8 @@ trait KuduConverter {
       case Type.BYTES => {
         field.schema().name() match {
           case Decimal.LOGICAL_NAME => {
-            val precision = field.schema().parameters().get("connect.decimal.precision").asInstanceOf[Int]
-            val scale = field.schema().parameters().get("scale").asInstanceOf[Int]
+            val precision = field.schema().parameters().get("connect.decimal.precision").toInt
+            val scale = field.schema().parameters().get("scale").toInt
             new ColumnSchemaBuilder(fieldName, org.apache.kudu.Type.DECIMAL).typeAttributes(
               new ColumnTypeAttributes.ColumnTypeAttributesBuilder()
                 .precision(precision).scale(scale).build()

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
@@ -211,8 +211,8 @@ object DbHandler extends StrictLogging with KuduConverter {
     * @param client  A Kudu client to execute the DDL
     **/
   def alterTable(table: String,
-                 old: connectSchema,
-                 current: connectSchema,
+                 old: kuduSchema,
+                 current: kuduSchema,
                  client: KuduClient): KuduTable = {
     val ato = compare(old, current)
     ato.foreach(a => executeAlterTable(a, table, client))
@@ -244,12 +244,12 @@ object DbHandler extends StrictLogging with KuduConverter {
     * @param current The current schema
     * @return A list of AlterTableOptions
     **/
-  def compare(old: connectSchema, current: connectSchema): List[AlterTableOptions] = {
+  def compare(old: kuduSchema, current: kuduSchema): List[AlterTableOptions] = {
     ///look for new fields
     logger.info("Found a difference in the schemas.")
-    val diff = current.fields().toSet.diff(old.fields().toSet)
+    val diff = current.getColumns.toSet.diff(old.getColumns.toSet)
     diff.map(d => {
-      val schema = convertConnectField(d)
+      val schema = current.getColumn(d.getName)
       val ato = new AlterTableOptions()
       if (null == schema.getDefaultValue) {
         logger.info(s"Adding nullable column ${schema.getName}, type ${schema.getType}")

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/DbHandler.scala
@@ -253,10 +253,16 @@ object DbHandler extends StrictLogging with KuduConverter {
       val ato = new AlterTableOptions()
       if (null == schema.getDefaultValue) {
         logger.info(s"Adding nullable column ${schema.getName}, type ${schema.getType}")
-        ato.addNullableColumn(schema.getName, schema.getType)
+        ato.addColumn(new ColumnSchema.ColumnSchemaBuilder(schema.getName, schema.getType)
+          .nullable(true)
+          .typeAttributes(schema.getTypeAttributes)
+          .build())
       } else {
         logger.info(s"Adding column ${schema.getName}, type ${schema.getType}, default ${schema.getDefaultValue}")
-        ato.addColumn(schema.getName, schema.getType, schema.getDefaultValue)
+        ato.addColumn(new ColumnSchema.ColumnSchemaBuilder(schema.getName, schema.getType)
+          .defaultValue(schema.getDefaultValue)
+          .typeAttributes(schema.getTypeAttributes)
+          .build())
       }
     }).toList
   }

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/KuduWriter.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/KuduWriter.scala
@@ -187,16 +187,21 @@ class KuduWriter(client: KuduClient, setting: KuduSettings) extends StrictLoggin
       val schema = record.valueSchema()
       val version = schema.version()
       val table = setting.topicTables(topic)
-      val cachedSchema = schemaCache.getOrElse(topic, SchemaMap(version, schema))
 
+      var currentColumnsSize = record.valueSchema().fields().size()
+      var oladKuduTableSchema = client.openTable(table).getSchema
+      var oldColumnsSize = oladKuduTableSchema.getColumns.size()
       //allow evolution
-      val evolving = cachedSchema.version < version
+      val evolving = oldColumnsSize < currentColumnsSize
 
+      var kcql = setting.kcql.filter(r => r.getTarget.trim == table)
+      var currentKuduTableSchema = convertToKuduSchema(record, kcql.head)
       //if table is allowed to evolve all the table
       if (evolving) {
-        logger.info(s"Schema change detected for $topic mapped to table $table. Old schema version " +
-          s"${cachedSchema.version} new version $version")
-        val kuduTable = DbHandler.alterTable(table, cachedSchema.schema, schema, client)
+        logger.info(s"Schema change detected for $topic mapped to table $table. Old schema columns size " +
+          s"$oldColumnsSize new columns size $currentColumnsSize")
+        val kuduTable = DbHandler.alterTable(table, oladKuduTableSchema, currentKuduTableSchema, client)
+
         kuduTablesCache.update(topic, kuduTable)
         schemaCache.update(topic, SchemaMap(version, schema))
       } else {

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/KuduWriter.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/KuduWriter.scala
@@ -188,12 +188,12 @@ class KuduWriter(client: KuduClient, setting: KuduSettings) extends StrictLoggin
       val version = schema.version()
       val table = setting.topicTables(topic)
 
-      var currentKcql = setting.kcql.filter(r => r.getTarget.trim == table)
-      var currentKuduTableSchema = convertToKuduSchema(record, currentKcql.head)
-      var currentColumnsSize = record.valueSchema().fields().size()
+      val currentKcql = setting.kcql.filter(r => r.getTarget.trim == table)
+      val currentKuduTableSchema = convertToKuduSchema(record, currentKcql.head)
+      val currentColumnsSize = record.valueSchema().fields().size()
 
-      var oladKuduTableSchema = kuduTablesCache(topic).getSchema
-      var oldColumnsSize = oladKuduTableSchema.getColumns.size()
+      val oldKuduTableSchema = kuduTablesCache(topic).getSchema
+      val oldColumnsSize = oldKuduTableSchema.getColumns.size()
 
       //allow evolution
       val evolving = oldColumnsSize < currentColumnsSize
@@ -201,8 +201,8 @@ class KuduWriter(client: KuduClient, setting: KuduSettings) extends StrictLoggin
       //if table is allowed to evolve all the table
       if (evolving) {
         logger.info(s"Schema change detected for $topic mapped to table $table. Old schema columns size " +
-          s"$oladKuduTableSchema new columns size $currentColumnsSize")
-        val kuduTable = DbHandler.alterTable(table, oladKuduTableSchema, currentKuduTableSchema, client)
+          s"$oldKuduTableSchema new columns size $currentColumnsSize")
+        val kuduTable = DbHandler.alterTable(table, oldKuduTableSchema, currentKuduTableSchema, client)
 
         kuduTablesCache.update(topic, kuduTable)
         schemaCache.update(topic, SchemaMap(version, schema))

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestBase.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestBase.scala
@@ -23,12 +23,15 @@ package com.datamountaineer.streamreactor.connect.kudu
 
 import java.nio.ByteBuffer
 import java.util
+import java.util.{ArrayList, List}
 
 import com.datamountaineer.streamreactor.connect.kudu.config.{KuduConfigConstants, WriteFlushMode}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
+import org.apache.kudu.ColumnSchema.ColumnSchemaBuilder
+import org.apache.kudu.{ColumnSchema, Type}
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
@@ -147,6 +150,27 @@ trait TestBase extends WordSpec with BeforeAndAfter with Matchers {
       .build
   }
 
+  def createKuduSchema2: org.apache.kudu.Schema = {
+    val columns = new util.ArrayList[ColumnSchema]
+    val idField = new ColumnSchema.ColumnSchemaBuilder("id", Type.STRING).key(true).build
+    columns.add(idField)
+    val intField = new ColumnSchema.ColumnSchemaBuilder("int_field", Type.INT32).build
+    columns.add(intField)
+    val longField = new ColumnSchema.ColumnSchemaBuilder("long_field", Type.INT64).build
+    columns.add(longField)
+    val stringField = new ColumnSchema.ColumnSchemaBuilder("string_field", Type.STRING).build
+    columns.add(stringField)
+    val floatField = new ColumnSchema.ColumnSchemaBuilder("float_field", Type.FLOAT).build
+    columns.add(floatField)
+    val float64Field = new ColumnSchema.ColumnSchemaBuilder("float64_field", Type.DOUBLE).build
+    columns.add(float64Field)
+    val booleanField = new ColumnSchema.ColumnSchemaBuilder("boolean_field", Type.BOOL).build
+    columns.add(booleanField)
+    val int64Field = new ColumnSchema.ColumnSchemaBuilder("int64_field", Type.INT64).defaultValue(20.toLong).build
+    columns.add(int64Field)
+    new org.apache.kudu.Schema(columns)
+  }
+
   def createSchema3: Schema = {
     SchemaBuilder.struct.name("record")
       .version(1)
@@ -161,6 +185,7 @@ trait TestBase extends WordSpec with BeforeAndAfter with Matchers {
       .field("new_field", Schema.STRING_SCHEMA)
       .build
   }
+
 
   def createSchema4: Schema = {
     SchemaBuilder.struct.name("record")
@@ -177,6 +202,29 @@ trait TestBase extends WordSpec with BeforeAndAfter with Matchers {
       .build
   }
 
+  def createKuduSchema4: org.apache.kudu.Schema = {
+    val columns = new util.ArrayList[ColumnSchema]
+    val idField = new ColumnSchema.ColumnSchemaBuilder("id", Type.STRING).key(true).build
+    columns.add(idField)
+    val intField = new ColumnSchema.ColumnSchemaBuilder("int_field", Type.INT32).build
+    columns.add(intField)
+    val longField = new ColumnSchema.ColumnSchemaBuilder("long_field", Type.INT64).build
+    columns.add(longField)
+    val stringField = new ColumnSchema.ColumnSchemaBuilder("string_field", Type.STRING).build
+    columns.add(stringField)
+    val floatField = new ColumnSchema.ColumnSchemaBuilder("float_field", Type.FLOAT).build
+    columns.add(floatField)
+    val float64Field = new ColumnSchema.ColumnSchemaBuilder("float64_field", Type.DOUBLE).build
+    columns.add(float64Field)
+    val booleanField = new ColumnSchema.ColumnSchemaBuilder("boolean_field", Type.BOOL).build
+    columns.add(booleanField)
+    val byteField = new ColumnSchema.ColumnSchemaBuilder("byte_field", Type.BINARY).build
+    columns.add(byteField)
+    val int64Field = new ColumnSchema.ColumnSchemaBuilder("int64_field", Type.INT64).defaultValue(20.toLong).build
+    columns.add(int64Field)
+    new org.apache.kudu.Schema(columns)
+  }
+
   def createSchema5: Schema = {
     SchemaBuilder.struct.name("record")
       .version(2)
@@ -191,6 +239,31 @@ trait TestBase extends WordSpec with BeforeAndAfter with Matchers {
       .field("int64_field", SchemaBuilder.int64().defaultValue(20.toLong).build())
       .field("new_field", SchemaBuilder.string().defaultValue("").build())
       .build
+  }
+
+  def createKuduSchema5: org.apache.kudu.Schema = {
+    val columns = new util.ArrayList[ColumnSchema]
+    val idField = new ColumnSchema.ColumnSchemaBuilder("id", Type.STRING).key(true).build
+    columns.add(idField)
+    val intField = new ColumnSchema.ColumnSchemaBuilder("int_field", Type.INT32).build
+    columns.add(intField)
+    val longField = new ColumnSchema.ColumnSchemaBuilder("long_field", Type.INT64).build
+    columns.add(longField)
+    val stringField = new ColumnSchema.ColumnSchemaBuilder("string_field", Type.STRING).build
+    columns.add(stringField)
+    val floatField = new ColumnSchema.ColumnSchemaBuilder("float_field", Type.FLOAT).build
+    columns.add(floatField)
+    val float64Field = new ColumnSchema.ColumnSchemaBuilder("float64_field", Type.DOUBLE).build
+    columns.add(float64Field)
+    val booleanField = new ColumnSchema.ColumnSchemaBuilder("boolean_field", Type.BOOL).build
+    columns.add(booleanField)
+    val byteField = new ColumnSchema.ColumnSchemaBuilder("byte_field", Type.BINARY).build
+    columns.add(byteField)
+    val int64Field = new ColumnSchema.ColumnSchemaBuilder("int64_field", Type.INT64).defaultValue(20.toLong).build
+    columns.add(int64Field)
+    val newField = new ColumnSchema.ColumnSchemaBuilder("new_field", Type.STRING).defaultValue("").build
+    columns.add(newField)
+    new org.apache.kudu.Schema(columns)
   }
 
   //build a test record
@@ -243,6 +316,28 @@ trait TestBase extends WordSpec with BeforeAndAfter with Matchers {
       .field("boolean_field", Schema.BOOLEAN_SCHEMA)
       .field("byte_field", Schema.BYTES_SCHEMA)
       .build
+  }
+
+  def createKuduSchema: org.apache.kudu.Schema = {
+    val columns = new util.ArrayList[ColumnSchema]
+    val idField = new ColumnSchemaBuilder("id", Type.STRING).key(true).build()
+    columns.add(idField)
+    val intField = new ColumnSchemaBuilder("int_field", Type.INT32).build()
+    columns.add(intField)
+    val longField = new ColumnSchemaBuilder("long_field", Type.INT64).build()
+    columns.add(longField)
+    val stringField = new ColumnSchemaBuilder("string_field", Type.STRING).build()
+    columns.add(stringField)
+    val floatField = new ColumnSchemaBuilder("float_field", Type.FLOAT).build()
+    columns.add(floatField)
+    val float64Field = new ColumnSchemaBuilder("float64_field", Type.DOUBLE).build()
+    columns.add(float64Field)
+    val booleanField = new ColumnSchemaBuilder("boolean_field", Type.BOOL).build()
+    columns.add(booleanField)
+    val byteField = new ColumnSchemaBuilder("byte_field", Type.BINARY).build()
+    columns.add(byteField)
+
+    new org.apache.kudu.Schema(columns)
   }
 
   //build a test record

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestDbHandler.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestDbHandler.scala
@@ -35,17 +35,17 @@ import scala.util.Try
 class TestDbHandler extends TestBase with MockitoSugar with KuduConverter {
 
   "Should identify new columns in schema2" in {
-    val diff = DbHandler.compare(createSchema, createSchema2)
+    val diff = DbHandler.compare(createKuduSchema, createKuduSchema2)
     diff.size shouldBe 1
   }
 
   "Should identify new columns in schema4 with default" in {
-    val diff = DbHandler.compare(createSchema, createSchema4)
+    val diff = DbHandler.compare(createKuduSchema, createKuduSchema4)
     diff.size shouldBe 1
   }
 
   "Should not identify new columns in schema" in {
-    val diff = DbHandler.compare(createSchema, createSchema)
+    val diff = DbHandler.compare(createKuduSchema, createKuduSchema)
     diff.size shouldBe 0
   }
 
@@ -201,12 +201,12 @@ class TestDbHandler extends TestBase with MockitoSugar with KuduConverter {
     val client = mock[KuduClient]
     val table = mock[KuduTable]
     val atrm = mock[AlterTableResponse]
-    val ato = DbHandler.compare(createSchema, createSchema2).head
+    val ato = DbHandler.compare(createKuduSchema, createKuduSchema4).head
     when(client.tableExists(TABLE)).thenReturn(true)
     when(client.alterTable(TABLE, ato)).thenReturn(atrm)
     when(client.openTable(TABLE)).thenReturn(table)
     when(client.isAlterTableDone(TABLE)).thenReturn(true)
-    val ret = DbHandler.alterTable(TABLE, createSchema, createSchema2, client)
+    val ret = DbHandler.alterTable(TABLE, createKuduSchema, createKuduSchema4, client)
     ret.isInstanceOf[KuduTable] shouldBe true
   }
 

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduWriter.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduWriter.scala
@@ -213,7 +213,6 @@ class TestKuduWriter extends TestBase with KuduConverter with MockitoSugar with 
     when(client.getTablesList).thenReturn(resp)
     when(resp.getTablesList).thenReturn(List.empty[String].asJava)
 
-
     val writer = new KuduWriter(client, settings)
     writer.write(getTestRecords.toSeq)
     writer.close()
@@ -229,9 +228,9 @@ class TestKuduWriter extends TestBase with KuduConverter with MockitoSugar with 
 
     val rec1 = createSinkRecord(createRecord(schema1, "1"), TOPIC, 1)
     val rec2 = createSinkRecord(createRecord5(schema2, "2"), TOPIC, 2)
-    val kuduSchema = convertToKuduSchema(rec1, kcql)
+    val kuduSchema = createKuduSchema
 
-    val kuduSchema2 = convertToKuduSchema(rec2.valueSchema(), kcql)
+    val kuduSchema2 = createKuduSchema5
     val kuduRow2 = kuduSchema2.newPartialRow()
 
     //mock out kudu client


### PR DESCRIPTION
Hi, I found a bug about adding columns:
    If i add some columns in my avro schema, and doesn't send any record by this new schema, then I restart kafka-connect-kudu task.
    After the task is restarted, I send some record by this new schema, however, the new columns are not added to the kudu table. 
   As we know, the condition of evolution is to judge  whether the schema version is changed or not，and when we restart this task，we will get the same schema version always.I change the condition of evolution to  judge whether the current record schema columns' size is larger than kudu table columns' size or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/580)
<!-- Reviewable:end -->
