### PR TITLE
Add redis pubsub sink

### DIFF
--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala
@@ -20,7 +20,7 @@ import java.util
 
 import com.datamountaineer.streamreactor.connect.errors.ErrorPolicyEnum
 import com.datamountaineer.streamreactor.connect.redis.sink.config.{RedisConfig, RedisConfigConstants, RedisSinkSettings}
-import com.datamountaineer.streamreactor.connect.redis.sink.writer.{RedisCache, RedisInsertSortedSet, RedisMultipleSortedSets, RedisWriter}
+import com.datamountaineer.streamreactor.connect.redis.sink.writer.{RedisCache, RedisPubSub, RedisInsertSortedSet, RedisMultipleSortedSets, RedisWriter}
 import com.datamountaineer.streamreactor.connect.utils.{JarManifest, ProgressCounter}
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
@@ -68,6 +68,8 @@ class RedisSinkTask extends SinkTask with StrictLogging {
     // Insert Sorted Set mode requires: target name of SortedSet to be defined and STOREAS SortedSet syntax to be provided
     val mode_INSERT_SS = filterModeInsertSS(settings)
 
+    val mode_PUBSUB = filterModePubSub(settings)
+
     // Multiple Sorted Sets mode requires: 1 Primary Key to be defined and STORE SortedSet syntax to be provided
     val mode_PK_SS = filterModePKSS(settings)
 
@@ -78,6 +80,9 @@ class RedisSinkTask extends SinkTask with StrictLogging {
     } ++ mode_INSERT_SS.kcqlSettings.headOption.map { _ =>
       logger.info("Starting " + mode_INSERT_SS.kcqlSettings.size + " KCQLs with Redis Insert Sorted Set mode")
       List(new RedisInsertSortedSet(mode_INSERT_SS))
+    } ++ mode_PUBSUB.kcqlSettings.headOption.map { _ =>
+      logger.info("Starting " + mode_PUBSUB.kcqlSettings.size + " KCQLs with Redis PubSub mode")
+      List(new RedisPubSub(mode_PUBSUB))
     } ++ mode_PK_SS.kcqlSettings.headOption.map { _ =>
       logger.info("Starting " + mode_PK_SS.kcqlSettings.size + " KCQLs with Redis Multiple Sorted Sets mode")
       List(new RedisMultipleSortedSets(mode_PK_SS))
@@ -114,6 +119,23 @@ class RedisSinkTask extends SinkTask with StrictLogging {
       .filter { k =>
         Option(k.kcqlConfig.getStoredAs).map(_.toUpperCase).contains("SORTEDSET") &&
           k.kcqlConfig.getTarget != null &&
+          k.kcqlConfig.getPrimaryKeys.isEmpty
+      }
+  )
+
+  /**
+    * Construct a RedisSinkSettings object containing all the kcqlConfigs that use the PubSub mode.
+    * This function will filter by the presence of the "STOREAS" keyword and a target, as well as the absence of primary keys.
+    *
+    * KCQL Example: SELECT * FROM cpuTopic STOREAS PubSub (channel=channel)
+    *
+    * @param settings The RedisSinkSettings containing all kcqlConfigs.
+    * @return A RedisSinkSettings object containing only the kcqlConfigs that use the PubSub mode.
+    */
+  def filterModePubSub(settings: RedisSinkSettings): RedisSinkSettings = settings.copy(kcqlSettings =
+    settings.kcqlSettings
+      .filter { k =>
+        Option(k.kcqlConfig.getStoredAs).map(_.toUpperCase).contains("PUBSUB") &&
           k.kcqlConfig.getPrimaryKeys.isEmpty
       }
   )

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/PubSubSupport.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/PubSubSupport.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Datamountaineer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.redis.sink.writer
+
+import com.datamountaineer.kcql.Kcql
+import com.typesafe.scalalogging.slf4j.StrictLogging
+
+import scala.collection.JavaConverters._
+
+trait PubSubSupport extends StrictLogging {
+
+  // How to 'score' each message
+  def getChannelField(kcqlConfig: Kcql): String = {
+    val pubSubParams = kcqlConfig.getStoredAsParameters.asScala
+    val channelField = if (pubSubParams.keys.exists(k => k.equalsIgnoreCase("channel")))
+      pubSubParams.find { case (k, _) => k.equalsIgnoreCase("channel") }.get._2
+    else {
+      logger.info("You have not defined a 'channel' field. We'll try to fall back to 'channel' field")
+      "channel"
+    }
+    channelField
+  }
+
+//   assert(SS.isValid, "The SortedSet definition at Redis accepts only case sensitive alphabetic characters")
+
+}

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisPubSub.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisPubSub.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Datamountaineer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.redis.sink.writer
+
+import com.datamountaineer.kcql.Kcql
+import com.datamountaineer.streamreactor.connect.redis.sink.config.{RedisKCQLSetting, RedisSinkSettings}
+import com.datamountaineer.streamreactor.connect.rowkeys.StringStructFieldsStringKeyBuilder
+import org.apache.kafka.connect.sink.SinkRecord
+
+import scala.collection.JavaConversions._
+import scala.util.Try
+
+/**
+  * A generic Redis `writer` that can store data into Redis PubSub / KCQL
+  *
+  * Requires KCQL syntax:   INSERT .. SELECT .. STOREAS PubSub
+  *
+  * If a field <channel> exists it will automatically be used as the Redis PubSub topic.
+  * Otherwise you would need to explicitly define how the values will be scored.
+  *
+  * Examples:
+  *
+  * SELECT * from cpuTopic STOREAS PubSub
+  * SELECT * from cpuTopic STOREAS PubSub (channel=channel)
+  */
+class RedisPubSub(sinkSettings: RedisSinkSettings) extends RedisWriter with PubSubSupport {
+
+  apply(sinkSettings)
+
+  val configs: Set[Kcql] = sinkSettings.kcqlSettings.map(_.kcqlConfig)
+  configs.foreach { c =>
+//    assert(c.getTarget.length > 0, "Add to your KCQL syntax : INSERT INTO REDIS_KEY_NAME ")
+    assert(c.getSource.trim.length > 0, "You need to define one (1) topic to source data. Add to your KCQL syntax: SELECT * FROM topicName")
+    val allFields = if (c.getIgnoredFields.isEmpty) false else true
+    assert(c.getFields.nonEmpty || allFields, "You need to SELECT at least one field from the topic to be published to the redis channel. Please review the KCQL syntax of the connector")
+    assert(c.getPrimaryKeys.isEmpty, "They keyword PK (Primary Key) is not supported in Redis PUBSUB mode. Please review the KCQL syntax of connector")
+    assert(c.getStoredAs.equalsIgnoreCase("PubSub"), "This mode requires the KCQL syntax: STOREAS PubSub")
+  }
+
+  // Write a sequence of SinkRecords to Redis
+  override def write(records: Seq[SinkRecord]): Unit = {
+    if (records.isEmpty)
+      logger.debug("No records received on 'PUBSUB' Redis writer")
+    else {
+      logger.debug(s"'PUBSUB' Redis writer received ${records.size} records")
+      insert(records.groupBy(_.topic))
+    }
+  }
+
+  // Insert a batch of sink records
+  def insert(records: Map[String, Seq[SinkRecord]]): Unit = {
+    records.foreach({
+      case (topic, sinkRecords: Seq[SinkRecord]) => {
+        val topicSettings: Set[RedisKCQLSetting] = sinkSettings.kcqlSettings.filter(_.kcqlConfig.getSource == topic)
+        if (topicSettings.isEmpty)
+          logger.warn(s"Received a batch for topic $topic - but no KCQL supports it")
+        val t = Try {
+          sinkRecords.foreach { record =>
+            topicSettings.map { KCQL =>
+              // Get a SinkRecord
+              val recordToSink = convert(record, fields = KCQL.fieldsAndAliases, ignoreFields = KCQL.ignoredFields)
+              // Use the target to name the SortedSet
+              val payload = convertValueToJson(recordToSink)
+
+              val channelField = getChannelField(KCQL.kcqlConfig)
+              val channel = StringStructFieldsStringKeyBuilder(Seq(channelField)).build(record)
+
+              logger.debug(s"PUBLISH $channel  channel = $channel  payload = ${payload.toString}")
+              val response = jedis.publish(channel, payload.toString)
+
+              logger.debug(s"Published a new message to $response clients.")
+              response
+            }
+          }
+        }
+        handleTry(t)
+      }
+      logger.debug(s"Published ${sinkRecords.size} messages for topic $topic")
+    })
+  }
+
+}

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisPubSubTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisPubSubTest.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Datamountaineer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.redis.sink.writer
+
+import com.datamountaineer.streamreactor.connect.redis.sink.config.{RedisConfig, RedisConfigConstants, RedisConnectionInfo, RedisSinkSettings}
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.apache.kafka.connect.sink.SinkRecord
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import redis.clients.jedis.{Jedis, JedisPubSub}
+import redis.embedded.RedisServer
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+
+class RedisPubSubTest extends WordSpec with Matchers with BeforeAndAfterAll with MockitoSugar {
+
+  val redisServer = new RedisServer(6379)
+
+  override def beforeAll() = redisServer.start()
+
+  override def afterAll() = redisServer.stop()
+
+  "Redis PUBSUB writer" should {
+
+    "write Kafka records to a Redis PubSub" in {
+
+      val TOPIC = "cpuTopic"
+      val KCQL = s"SELECT * from $TOPIC STOREAS PubSub (channel=type)"
+      println("Testing KCQL : " + KCQL)
+      val props = Map(
+        RedisConfigConstants.REDIS_HOST->"localhost",
+        RedisConfigConstants.REDIS_PORT->"6379",
+        RedisConfigConstants.KCQL_CONFIG->KCQL
+      ).asJava
+
+      val config = RedisConfig(props)
+      val connectionInfo = new RedisConnectionInfo("localhost", 6379, None)
+      val settings = RedisSinkSettings(config)
+      val writer = new RedisPubSub(settings)
+
+      val schema = SchemaBuilder.struct().name("com.example.Cpu")
+        .field("type", Schema.STRING_SCHEMA)
+        .field("temperature", Schema.FLOAT64_SCHEMA)
+        .field("voltage", Schema.FLOAT64_SCHEMA)
+        .field("ts", Schema.INT64_SCHEMA).build()
+
+      val struct1 = new Struct(schema).put("type", "Xeon").put("temperature", 60.4).put("voltage", 90.1).put("ts", 1482180657010L)
+      val struct2 = new Struct(schema).put("type", "i7").put("temperature", 62.1).put("voltage", 103.3).put("ts", 1482180657020L)
+      val struct3 = new Struct(schema).put("type", "i7-i").put("temperature", 64.5).put("voltage", 101.1).put("ts", 1482180657030L)
+
+      val sinkRecord1 = new SinkRecord(TOPIC, 0, null, null, schema, struct1, 1)
+      val sinkRecord2 = new SinkRecord(TOPIC, 0, null, null, schema, struct2, 2)
+      val sinkRecord3 = new SinkRecord(TOPIC, 0, null, null, schema, struct3, 3)
+
+      val jedis = new Jedis(connectionInfo.host, connectionInfo.port)
+      // Clean up in-memory jedis
+      jedis.flushAll()
+
+      val messagesMap = collection.mutable.Map[String, ListBuffer[String]]()
+
+      val t = new Thread {
+        private val pubsub = new JedisPubSub {
+          override def onMessage(channel: String, message: String): Unit = {
+            messagesMap.get(channel) match {
+              case Some(msgs) => messagesMap.put(channel, msgs += message)
+              case None => messagesMap.put(channel, ListBuffer(message))
+            }
+          }
+        }
+
+        override def run(): Unit = {
+          jedis.subscribe(pubsub, "Xeon", "i7", "i7-i")
+        }
+
+        override def interrupt(): Unit = {
+          pubsub.punsubscribe("*")
+          super.interrupt()
+        }
+      }
+      t.start()
+      t.join(5000)
+      if (t.isAlive) t.interrupt()
+
+      writer.write(Seq(sinkRecord1))
+      writer.write(Seq(sinkRecord2, sinkRecord3))
+
+      messagesMap.size shouldBe 3
+
+      messagesMap("Xeon").head shouldBe """{"type":"Xeon","temperature":60.4,"voltage":90.1,"ts":1482180657010}"""
+      messagesMap("i7").head shouldBe """{"type":"i7","temperature":62.1,"voltage":103.3,"ts":1482180657020}"""
+      messagesMap("i7-i").head shouldBe """{"type":"i7-i","temperature":64.5,"voltage":101.1,"ts":1482180657030}"""
+    }
+  }
+}


### PR DESCRIPTION
This pr adds a redis pubsub sink.

You chose a "channel" field which decides which redis channel to publish into.

This would allow you to use redis as a filter/router for a kafka queue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor/591)
<!-- Reviewable:end -->
