### PR TITLE
feat(MQTT): replicate shared subscription to all tasks if enabled

### DIFF
--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfig.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfig.scala
@@ -79,6 +79,10 @@ object MqttSourceConfig {
     .define(MqttConfigConstants.POLLING_TIMEOUT_CONFIG, Type.INT, MqttConfigConstants.POLLING_TIMEOUT_DEFAULT,
       Importance.LOW, MqttConfigConstants.POLLING_TIMEOUT_DOC,
       "Manager", 1, ConfigDef.Width.MEDIUM, MqttConfigConstants.POLLING_TIMEOUT_DISPLAY)
+    .define(MqttConfigConstants.REPLICATE_SHARED_SUBSCIRPTIONS_CONFIG, Type.BOOLEAN,
+      MqttConfigConstants.REPLICATE_SHARED_SUBSCIRPTIONS_DEFAULT, Importance.LOW,
+      MqttConfigConstants.REPLICATE_SHARED_SUBSCIRPTIONS_DOC, "Manager", 2, ConfigDef.Width.MEDIUM,
+      MqttConfigConstants.REPLICATE_SHARED_SUBSCIRPTIONS_DISPLAY)
 
     .define(MqttConfigConstants.LOG_MESSAGE_ARRIVED_KEY, Type.BOOLEAN, MqttConfigConstants.LOG_MESSAGE_ARRIVED_DEFAULT,
       Importance.MEDIUM, MqttConfigConstants.LOG_MESSAGE_ARRIVED_DISPLAY,

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
@@ -104,6 +104,11 @@ object MqttConfigConstants {
   val AVRO_CONVERTERS_SCHEMA_FILES_DOC = "If the AvroConverter is used you need to provide an avro Schema to be able to read and translate the raw bytes to an avro record. The format is $MQTT_TOPIC=$PATH_TO_AVRO_SCHEMA_FILE"
   val AVRO_CONVERTERS_SCHEMA_FILES_DEFAULT = ""
 
+  val REPLICATE_SHARED_SUBSCIRPTIONS_CONFIG = s"$CONNECTOR_PREFIX.share.replicate"
+  val REPLICATE_SHARED_SUBSCIRPTIONS_DOC = "Replicate the shared subscriptions to all tasks instead of distributing them"
+  val REPLICATE_SHARED_SUBSCIRPTIONS_DEFAULT = false
+  val REPLICATE_SHARED_SUBSCIRPTIONS_DISPLAY = "Activate shared subscriptions replication"
+
   val PROGRESS_COUNTER_ENABLED = PROGRESS_ENABLED_CONST
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
@@ -40,6 +40,7 @@ case class MqttSourceSettings(connection: String,
                               sslCACertFile: Option[String],
                               sslCertFile: Option[String],
                               sslCertKeyFile: Option[String],
+                              replicateShared: Boolean = false,
                               enableProgress: Boolean = MqttConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
                               logMessageReceived: Boolean = false) {
 
@@ -84,6 +85,8 @@ object MqttSourceSettings {
       case _ => throw new ConfigException(s"You can't define one of the ${MqttConfigConstants.SSL_CA_CERT_CONFIG},${MqttConfigConstants.SSL_CERT_CONFIG}, ${MqttConfigConstants.SSL_CERT_KEY_CONFIG} without the other")
     }
 
+    val replicateShared = config.getBoolean(MqttConfigConstants.REPLICATE_SHARED_SUBSCIRPTIONS_CONFIG)
+
     val progressEnabled = config.getBoolean(MqttConfigConstants.PROGRESS_COUNTER_ENABLED)
 
     val converters = kcql.map(k => {
@@ -121,6 +124,7 @@ object MqttSourceSettings {
       sslCACertFile,
       sslCertFile,
       sslCertKeyFile,
+      replicateShared,
       progressEnabled,
       config.getBoolean(MqttConfigConstants.LOG_MESSAGE_ARRIVED_KEY)
     )

--- a/kafka-connect-mqtt/src/test/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttSourceConnectorTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttSourceConnectorTest.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Datamountaineer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.mqtt.source
+
+import java.util
+
+import com.datamountaineer.streamreactor.connect.mqtt.config.{MqttConfigConstants, MqttSourceConfig, MqttSourceSettings}
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class MqttSourceConnectorTest extends WordSpec with Matchers {
+  val baseProps: Map[String, String] = Map(
+    MqttConfigConstants.HOSTS_CONFIG -> "tcp://0.0.0.0:1883",
+    MqttConfigConstants.QS_CONFIG -> "1"
+  )
+
+  val mqttSourceConnector = new MqttSourceConnector()
+  val targets = Array("test", "topic", "stream")
+
+  val normalSources = Array(
+    "/test/#",
+    "/mqttTopic/+/test",
+    "/stream",
+    "/some/other/topic",
+    "/alot/+/+/fourth"
+  )
+  val sharedSources = Array(
+    "$share/some-group/test/#",
+    "$share/aservice/mqttTopic/+/test",
+    "$share/connectorGroup/stream",
+    "$share/g1/some/other/topic",
+    "$share/grouped/alot/+/+/fourth"
+  )
+
+  val normalKcql: Array[String] = normalSources.zip(targets).map{
+    case (source, target) =>  s"INSERT INTO `$target` SELECT * FROM `$source`"
+  }
+  val sharedKcql: Array[String] = sharedSources.zip(targets).map{
+    case (source, target) =>  s"INSERT INTO `$target` SELECT * FROM `$source`"
+  }
+  val allKcql: Array[String] = normalKcql ++ sharedKcql
+
+  "The MqttSourceConnector" should {
+    "indicate that shared subscription instructions should be replicated" in {
+      all (sharedKcql.map(mqttSourceConnector.shouldReplicate)) should be (true)
+    }
+
+    "indicate that normal subscription instructions should not be replicated" in {
+      all (normalKcql.map(mqttSourceConnector.shouldReplicate)) should be (false)
+    }
+  }
+
+  "The MqttSourceConnector" when {
+    "the connect.mqtt.share.replicate option is activated" should {
+      val replicateProps = baseProps ++ Map(MqttConfigConstants.REPLICATE_SHARED_SUBSCIRPTIONS_CONFIG -> "true")
+
+      "correctly distribute instructions when there is no replicated instruction" in {
+        val props = replicateProps ++ Map(MqttConfigConstants.KCQL_CONFIG -> normalKcql.mkString(";"))
+        mqttSourceConnector.start(props.asJava)
+
+        val maxTasks = 2
+        val kcqls = extractKcqls(mqttSourceConnector.taskConfigs(maxTasks))
+        kcqls.flatten should have length normalKcql.length
+      }
+
+      "correctly distribute instructions when there is only replicated instructions" in {
+        val props = replicateProps ++ Map(MqttConfigConstants.KCQL_CONFIG -> sharedKcql.mkString(";"))
+        mqttSourceConnector.start(props.asJava)
+
+        val maxTasks = 2
+        val kcqls = extractKcqls(mqttSourceConnector.taskConfigs(maxTasks))
+        all (kcqls) should have length sharedKcql.length
+      }
+
+      "correctly distribute instructions when there is a mix of instructions" in {
+        val props = replicateProps ++ Map(MqttConfigConstants.KCQL_CONFIG -> allKcql.mkString(";"))
+        mqttSourceConnector.start(props.asJava)
+
+        val maxTasks = 2
+        val kcqls = extractKcqls(mqttSourceConnector.taskConfigs(maxTasks))
+        kcqls.flatten should have length(sharedKcql.length * maxTasks + normalKcql.length)
+        all (kcqls.map(_.length)) should be >= sharedKcql.length
+      }
+    }
+
+    "the connect.mqtt.share.replicate option is deactivated" should {
+      "not replicate shared instructions" in {
+        val props = baseProps ++ Map(MqttConfigConstants.KCQL_CONFIG -> allKcql.mkString(";"))
+        mqttSourceConnector.start(props.asJava)
+
+        val maxTasks = 2
+        val kcqls = extractKcqls(mqttSourceConnector.taskConfigs(maxTasks))
+        kcqls.flatten should have length allKcql.length
+      }
+    }
+  }
+
+  def extractKcqls(configs: util.List[util.Map[String, String]]): Array[Array[String]] = {
+    configs.asScala.map(t => MqttSourceSettings(MqttSourceConfig(t)).kcql).toArray
+  }
+}


### PR DESCRIPTION
Add an option called `connect.mqtt.share.replicate`.

When enabled, the messages published to shared subscriptions are
distributed over all tasks. Therefore, the work generated by a KCQL
instruction with a shared subscription is now divided over all tasks. It
is the job of the MQTT broker to load balance the messages to the
connected tasks.