### PR TITLE
Add support to Unix timestamp as double in the InfluxDB Sink connector

### DIFF
--- a/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/writers/TimestampValueCoerce.scala
+++ b/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/writers/TimestampValueCoerce.scala
@@ -32,6 +32,8 @@ object TimestampValueCoerce {
       case l: Long => l
       case s: String => Try(Instant.parse(s).toEpochMilli).getOrElse(throw new IllegalArgumentException(s"$s is not a valid format for timestamp, expected 'yyyy-MM-DDTHH:mm:ss.SSSZ'"))
       case d: Date => d.toInstant.toEpochMilli
+      /* Assume Unix timestamps in seconds with double precision, coerce to Long with milliseconds precision */
+      case d: Double => (d * 1E3).toLong
       case other => throw new IllegalArgumentException(s"Invalid value for field:${fieldPath.mkString(".")}.Value '$other' is not a valid field for the timestamp")
     }
   }

--- a/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/ValuesExtractorMapTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/ValuesExtractorMapTest.scala
@@ -180,6 +180,16 @@ class ValuesExtractorMapTest extends WordSpec with Matchers {
       }
     }
 
+    "assume unix timestamp in seconds if type is double and coerce to Long in milliseconds" in {
+
+      val payload = new java.util.HashMap[String, Any]()
+
+      payload.put("double", 1.56937031387E9)
+
+      TimestampValueCoerce(ValuesExtractor.extract(payload, Vector("double")))(Vector("double")) shouldBe 1569370313870L
+
+    }
+
     "throw an excception if a field is in bytes" in {
       val schema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstName", Schema.STRING_SCHEMA)


### PR DESCRIPTION
This PR is proposal to fix issue #625 

-  It assumes Unix timestamps in seconds if type is double and coerce to Long with milliseconds precision 
- Add test