### PR TITLE
Implement guard mechanism for sink tasks

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfig.scala
@@ -57,6 +57,10 @@ object S3SinkConfig extends PropsToConfigConverter[S3SinkConfig] {
       logMetrics                      = s3ConfigDefBuilder.getBoolean(LOG_METRICS_CONFIG)
       schemaChangeDetector            = s3ConfigDefBuilder.schemaChangeDetector()
       latestSchemaOptimizationEnabled = s3ConfigDefBuilder.getEnableLatestSchemaOptimization()
+      guardEnable                     = s3ConfigDefBuilder.getGuardEnable
+      guardBootstrap                  = s3ConfigDefBuilder.getGuardBootstrapServersOpt
+      guardTopic                      = s3ConfigDefBuilder.getGuardHeartbeatTopic
+      guardMs                         = s3ConfigDefBuilder.getGuardHeartbeatMs
     } yield S3SinkConfig(
       S3ConnectionConfig(s3ConfigDefBuilder.getParsedValues),
       sinkBucketOptions,
@@ -69,6 +73,10 @@ object S3SinkConfig extends PropsToConfigConverter[S3SinkConfig] {
       schemaChangeDetector        = schemaChangeDetector,
       skipNullValues              = s3ConfigDefBuilder.skipNullValues(),
       latestSchemaForWriteEnabled = latestSchemaOptimizationEnabled,
+      guardEnable,
+      guardBootstrap,
+      guardTopic,
+      guardMs,
     )
 
 }
@@ -85,4 +93,8 @@ case class S3SinkConfig(
   schemaChangeDetector:        SchemaChangeDetector,
   skipNullValues:              Boolean,
   latestSchemaForWriteEnabled: Boolean,
+  guardEnable:                 Boolean,
+  guardBootstrapServers:       Option[String],
+  guardHeartbeatTopic:         String,
+  guardHeartbeatMs:            Long,
 ) extends CloudSinkConfig[S3ConnectionConfig]

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDef.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDef.scala
@@ -21,6 +21,10 @@ import io.lenses.streamreactor.connect.aws.s3.config.processors.kcql.Deprecation
 import io.lenses.streamreactor.connect.cloud.common.config.CloudConfigDef
 import io.lenses.streamreactor.connect.cloud.common.config.IndexConfigKeys
 import io.lenses.streamreactor.connect.cloud.common.sink.config._
+import io.lenses.streamreactor.connect.cloud.common.sink.config.GuardConfigKeys
+import io.lenses.streamreactor.connect.cloud.common.sink.config.FlushConfigKeys
+import io.lenses.streamreactor.connect.cloud.common.sink.config.LocalStagingAreaConfigKeys
+import io.lenses.streamreactor.connect.cloud.common.sink.config.SchemaChangeConfigKeys
 import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingStrategyConfigKeys
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
@@ -34,7 +38,8 @@ object S3SinkConfigDef
     with IndexConfigKeys
     with SchemaChangeConfigKeys
     with SkipNullConfigKeys
-    with EnableLatestSchemaOptimizationConfigKeys {
+    with EnableLatestSchemaOptimizationConfigKeys
+    with GuardConfigKeys {
 
   override def connectorPrefix: String = CONNECTOR_PREFIX
 
@@ -54,6 +59,7 @@ object S3SinkConfigDef
     withSchemaChangeConfig(configDef)
     withSkipNullConfig(configDef)
     withEnableLatestSchemaOptimizationConfig(configDef)
+    addGuardSettingsToConfigDef(configDef)
   }
 
 }

--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilder.scala
@@ -19,12 +19,14 @@ import io.lenses.streamreactor.common.config.base.traits._
 import io.lenses.streamreactor.connect.aws.s3.config.DeleteModeSettings
 import io.lenses.streamreactor.connect.aws.s3.config.S3ConfigSettings
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
+import io.lenses.streamreactor.connect.cloud.common.sink.config.GuardSettings
 
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 case class S3SinkConfigDefBuilder(props: Map[String, AnyRef])
     extends BaseConfig(S3ConfigSettings.CONNECTOR_PREFIX, S3SinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
+    with GuardSettings
     with ErrorPolicySettings
     with RetryConfigSettings
     with DeleteModeSettings {

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/DatalakeSinkTask.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/DatalakeSinkTask.scala
@@ -16,19 +16,21 @@
 package io.lenses.streamreactor.connect.datalake.sink
 
 import com.azure.storage.file.datalake.DataLakeServiceClient
-import io.lenses.streamreactor.common.util.EitherUtils
-import io.lenses.streamreactor.common.util.JarManifest
+import io.lenses.streamreactor.common.util.{EitherUtils, JarManifest}
 import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
+import io.lenses.streamreactor.connect.cloud.common.guard.KafkaGuardSupport
 import io.lenses.streamreactor.connect.cloud.common.sink.CloudSinkTask
+import io.lenses.streamreactor.connect.cloud.common.sink.config.GuardConfigKeys
 import io.lenses.streamreactor.connect.cloud.common.storage.StorageInterface
 import io.lenses.streamreactor.connect.datalake.auth.DatalakeClientCreator
-import io.lenses.streamreactor.connect.datalake.config.AzureConfigSettings
-import io.lenses.streamreactor.connect.datalake.config.AzureConnectionConfig
+import io.lenses.streamreactor.connect.datalake.config.{AzureConfigSettings, AzureConnectionConfig}
 import io.lenses.streamreactor.connect.datalake.model.location.DatalakeLocationValidator
 import io.lenses.streamreactor.connect.datalake.sink.config.DatalakeSinkConfig
-import io.lenses.streamreactor.connect.datalake.storage.DatalakeFileMetadata
-import io.lenses.streamreactor.connect.datalake.storage.DatalakeStorageInterface
+import io.lenses.streamreactor.connect.datalake.storage.{DatalakeFileMetadata, DatalakeStorageInterface}
+import org.apache.kafka.common.TopicPartition
+
 object DatalakeSinkTask {}
+
 class DatalakeSinkTask
     extends CloudSinkTask[
       DatalakeFileMetadata,
@@ -39,7 +41,11 @@ class DatalakeSinkTask
       AzureConfigSettings.CONNECTOR_PREFIX,
       "/datalake-sink-ascii.txt",
       EitherUtils.unpackOrThrow(JarManifest.produceFromClass(DatalakeSinkTask.getClass)),
-    ) {
+    )
+    with KafkaGuardSupport {
+
+  override def guardConfigKeys: GuardConfigKeys =
+    new GuardConfigKeys { override def connectorPrefix: String = AzureConfigSettings.CONNECTOR_PREFIX }
 
   override def createClient(config: AzureConnectionConfig): Either[Throwable, DataLakeServiceClient] =
     DatalakeClientCreator.make(config)
@@ -56,4 +62,21 @@ class DatalakeSinkTask
   ): Either[Throwable, DatalakeSinkConfig] =
     DatalakeSinkConfig.fromProps(connectorTaskId, props)(DatalakeLocationValidator)
 
+  override def open(partitions: java.util.Collection[TopicPartition]): Unit = {
+    super.open(partitions)
+    onOpenGuard(partitions)
+  }
+
+  override def close(partitions: java.util.Collection[TopicPartition]): Unit =
+    try { onCloseGuard(partitions) }
+    finally super.close(partitions)
+
+  override def stop(): Unit =
+    try { onStopGuard() }
+    finally super.stop()
+
+  override protected def preWriteHeartbeat(
+    records: java.util.Collection[org.apache.kafka.connect.sink.SinkRecord],
+  ): Unit =
+    preWriteHeartbeatGuard()
 }

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfig.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfig.scala
@@ -53,6 +53,10 @@ object DatalakeSinkConfig extends PropsToConfigConverter[DatalakeSinkConfig] {
       logMetrics              = s3ConfigDefBuilder.getBoolean(LOG_METRICS_CONFIG)
       schemaChangeDetector    = s3ConfigDefBuilder.schemaChangeDetector()
       useLatestSchemaForWrite = s3ConfigDefBuilder.getEnableLatestSchemaOptimization()
+      guardEnable             = s3ConfigDefBuilder.getGuardEnable
+      guardBootstrap          = s3ConfigDefBuilder.getGuardBootstrapServersOpt
+      guardTopic              = s3ConfigDefBuilder.getGuardHeartbeatTopic
+      guardMs                 = s3ConfigDefBuilder.getGuardHeartbeatMs
     } yield DatalakeSinkConfig(
       AzureConnectionConfig(s3ConfigDefBuilder.getParsedValues, authMode),
       sinkBucketOptions,
@@ -64,6 +68,10 @@ object DatalakeSinkConfig extends PropsToConfigConverter[DatalakeSinkConfig] {
       schemaChangeDetector,
       skipNullValues              = s3ConfigDefBuilder.skipNullValues(),
       latestSchemaForWriteEnabled = useLatestSchemaForWrite,
+      guardEnable,
+      guardBootstrap,
+      guardTopic,
+      guardMs,
     )
 
 }
@@ -79,4 +87,8 @@ case class DatalakeSinkConfig(
   schemaChangeDetector:        SchemaChangeDetector,
   skipNullValues:              Boolean,
   latestSchemaForWriteEnabled: Boolean                     = false,
+  guardEnable:                 Boolean,
+  guardBootstrapServers:       Option[String],
+  guardHeartbeatTopic:         String,
+  guardHeartbeatMs:            Long,
 ) extends CloudSinkConfig[AzureConnectionConfig]

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDef.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDef.scala
@@ -28,6 +28,7 @@ import io.lenses.streamreactor.connect.datalake.config._
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.config.ConfigDef.Importance
 import org.apache.kafka.common.config.ConfigDef.Type
+import io.lenses.streamreactor.connect.cloud.common.sink.config.GuardConfigKeys
 
 object DatalakeSinkConfigDef
     extends CommonConfigDef
@@ -37,7 +38,8 @@ object DatalakeSinkConfigDef
     with IndexConfigKeys
     with SchemaChangeConfigKeys
     with SkipNullConfigKeys
-    with EnableLatestSchemaOptimizationConfigKeys {
+    with EnableLatestSchemaOptimizationConfigKeys
+    with GuardConfigKeys {
 
   override def connectorPrefix: String = CONNECTOR_PREFIX
 
@@ -67,6 +69,7 @@ object DatalakeSinkConfigDef
     withSchemaChangeConfig(configDef)
     withSkipNullConfig(configDef)
     withEnableLatestSchemaOptimizationConfig(configDef)
+    addGuardSettingsToConfigDef(configDef)
   }
 
 }

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/sink/config/DatalakeSinkConfigDefBuilder.scala
@@ -17,6 +17,7 @@ package io.lenses.streamreactor.connect.datalake.sink.config
 
 import io.lenses.streamreactor.common.config.base.traits._
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
+import io.lenses.streamreactor.connect.cloud.common.sink.config.GuardSettings
 import io.lenses.streamreactor.connect.datalake.config.AuthModeSettings
 import io.lenses.streamreactor.connect.datalake.config.AzureConfigSettings
 
@@ -25,6 +26,7 @@ import scala.jdk.CollectionConverters.MapHasAsScala
 case class DatalakeSinkConfigDefBuilder(props: Map[String, AnyRef])
     extends BaseConfig(AzureConfigSettings.CONNECTOR_PREFIX, DatalakeSinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
+    with GuardSettings
     with ErrorPolicySettings
     with RetryConfigSettings
     with AuthModeSettings {

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/guard/KafkaGuardClientProps.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/guard/KafkaGuardClientProps.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2025 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.cloud.common.guard
+
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+
+import java.util.Properties
+
+/**
+  * Builds Kafka Admin/Producer client properties for the guard components.
+*/
+object KafkaGuardClientProps {
+
+  private val GenericPassThroughPrefix   = "guard.client."
+  private val AdminPassThroughPrefix     = "guard.admin.client."
+  private val ProducerPassThroughPrefix  = "guard.producer.client."
+
+  private def copyAllowed(ctxProps: Map[String, String], allowed: java.util.Set[String], out: Properties): Unit = {
+    ctxProps.iterator.foreach {
+      case (k, v) if allowed.contains(k) => out.put(k, v)
+      case _                              => ()
+    }
+  }
+
+  private def applyPassThrough(ctxProps: Map[String, String], prefix: String, out: Properties): Unit = {
+    if (prefix.nonEmpty) {
+      ctxProps.iterator.foreach {
+        case (k, v) if k.startsWith(prefix) && k.length > prefix.length =>
+          out.put(k.substring(prefix.length), v)
+        case _ => ()
+      }
+    }
+  }
+
+  def buildAdminProps(bootstrapServers: String, ctxProps: Map[String, String]): Properties = {
+    val props = new Properties()
+    val adminAllowed = AdminClientConfig.configDef().names()
+
+    copyAllowed(ctxProps, adminAllowed, props)
+    applyPassThrough(ctxProps, GenericPassThroughPrefix, props)
+    applyPassThrough(ctxProps, AdminPassThroughPrefix, props)
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    props
+  }
+
+  def buildProducerProps(bootstrapServers: String, ctxProps: Map[String, String]): Properties = {
+    val props = new Properties()
+    val producerAllowed = ProducerConfig.configDef().names()
+
+    copyAllowed(ctxProps, producerAllowed, props)
+    applyPassThrough(ctxProps, GenericPassThroughPrefix, props)
+    applyPassThrough(ctxProps, ProducerPassThroughPrefix, props)
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    props
+  }
+}

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/guard/KafkaGuardSupport.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/guard/KafkaGuardSupport.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017-2025 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.cloud.common.guard
+
+import io.lenses.streamreactor.connect.cloud.common.sink.config.GuardConfigKeys
+import org.apache.kafka.clients.admin.{AdminClient, NewTopic}
+import org.apache.kafka.common.{TopicPartition => KafkaTopicPartition}
+
+import java.util.concurrent.TimeUnit
+
+
+private final case class GuardConfigKeysView(keys: GuardConfigKeys, props: Map[String, String]) {
+  private def raw(key: String): Option[String] = Option(props.getOrElse(key, null)).map(_.trim).filter(_.nonEmpty)
+  private def default[A](key: String): A = keys.DEFAULTS(key).asInstanceOf[A]
+
+  def getStringOpt(key: String): Option[String] = raw(key).orElse(Option(default[String](key))).filter(_ != null)
+  def getString(key: String): String = getStringOpt(key).getOrElse("")
+  def getBoolean(key: String): Boolean = raw(key).exists(_.equalsIgnoreCase("true")) || (!props.contains(key) && default[Boolean](key))
+  def getLong(key: String): Long = raw(key).flatMap(_.toLongOption).getOrElse(default[Long](key))
+  def getInt(key: String): Int = raw(key).flatMap(_.toIntOption).getOrElse(default[Int](key))
+  def getShort(key: String): Short = raw(key).flatMap(_.toShortOption).getOrElse(default[Short](key))
+}
+
+final case class GuardRuntimeConfig(
+  enable:           Boolean,
+  bootstrapServers: String,
+  heartbeatTopic:   String,
+  heartbeatMs:      Long,
+  topicAutoCreateEnable:            Boolean,
+  topicAutoCreatePartitions:        Int,
+  topicAutoCreateReplicationFactor: Short,
+)
+
+/**
+  * Mixin that encapsulates Kafka-based fencing lifecycle for sink tasks.
+  */
+trait KafkaGuardSupport { self: io.lenses.streamreactor.connect.cloud.common.sink.CloudSinkTask[_, _, _, _] =>
+
+  def guardConfigKeys: GuardConfigKeys
+
+  @volatile private var leaseGuard: Option[KafkaLeaseGuard] = None
+  private val heldLeases = scala.collection.mutable.Set[PartitionLease]()
+
+  protected def onOpenGuard(partitions: java.util.Collection[KafkaTopicPartition]): Unit = {
+    if (partitions.isEmpty) return
+    val ctxProps = getContextProps
+    val cfg = computeGuardConfig(ctxProps)
+
+    if (!cfg.enable) return
+    if (cfg.bootstrapServers.trim.isEmpty)
+      throw new org.apache.kafka.connect.errors.ConnectException("Guard enabled but no bootstrap.servers configured")
+
+    ensureHeartbeatTopic(cfg, ctxProps)
+    val producerProps = KafkaGuardClientProps.buildProducerProps(cfg.bootstrapServers, ctxProps)
+    val lg = new KafkaLeaseGuard(cfg.bootstrapServers, cfg.heartbeatTopic, cfg.heartbeatMs, connectorTaskId.name, producerProps)
+    leaseGuard = Some(lg)
+    acquireLeases(lg, partitions)
+  }
+
+  private def computeGuardConfig(ctxProps: Map[String, String]): GuardRuntimeConfig = {
+    val view = GuardConfigKeysView(guardConfigKeys, ctxProps)
+
+    val enable            = view.getBoolean(guardConfigKeys.GUARD_ENABLE)
+    val bootstrapResolved = view.getString(guardConfigKeys.GUARD_BOOTSTRAP_SERVERS)
+    val heartbeatTopic    = view.getString(guardConfigKeys.GUARD_HEARTBEAT_TOPIC)
+    val heartbeatMs       = view.getLong(guardConfigKeys.GUARD_HEARTBEAT_MS)
+    val acEnable          = view.getBoolean(guardConfigKeys.GUARD_TOPIC_AUTOCREATE_ENABLE)
+    val acPartitions      = view.getInt(guardConfigKeys.GUARD_TOPIC_AUTOCREATE_PARTITIONS)
+    val acRF              = view.getShort(guardConfigKeys.GUARD_TOPIC_AUTOCREATE_REPLICATION_FACTOR)
+
+    GuardRuntimeConfig(
+      enable                           = enable,
+      bootstrapServers                 = bootstrapResolved,
+      heartbeatTopic                   = heartbeatTopic,
+      heartbeatMs                      = heartbeatMs,
+      topicAutoCreateEnable            = acEnable,
+      topicAutoCreatePartitions        = acPartitions,
+      topicAutoCreateReplicationFactor = acRF,
+    )
+  }
+
+  private def acquireLeases(lg: KafkaLeaseGuard, partitions: java.util.Collection[KafkaTopicPartition]): Unit = {
+    val it = partitions.iterator()
+    while (it.hasNext) {
+      val tp = it.next()
+      val pl = PartitionLease(tp.topic(), tp.partition())
+      try { lg.acquire(pl); heldLeases.add(pl) }
+      catch {
+        case e: IllegalStateException =>
+          throw new org.apache.kafka.connect.errors.ConnectException(s"Lost lease for ${tp.topic()}-${tp.partition()}", e)
+      }
+    }
+  }
+
+  private def ensureHeartbeatTopic(cfg: GuardRuntimeConfig, ctxProps: Map[String, String]): Unit = {
+    var admin: AdminClient = null
+    try {
+      val adminProps = KafkaGuardClientProps.buildAdminProps(cfg.bootstrapServers, ctxProps)
+      admin = AdminClient.create(adminProps)
+      if (!topicExists(admin, cfg.heartbeatTopic)) {
+        if (cfg.topicAutoCreateEnable) {
+          logger.info(s"[KafkaGuardSupport][${connectorTaskId.name}] Heartbeat topic '${cfg.heartbeatTopic}' does not exist, attempting autocreation")
+          try {
+            val newTopic = new NewTopic(cfg.heartbeatTopic, cfg.topicAutoCreatePartitions, cfg.topicAutoCreateReplicationFactor)
+              .configs(java.util.Map.of("cleanup.policy", "compact"))
+            val _ = admin.createTopics(java.util.Collections.singleton(newTopic)).all().get(15, TimeUnit.SECONDS)
+          } catch {
+            case t: Throwable =>
+              logger.error(s"[KafkaGuardSupport][${connectorTaskId.name}] Heartbeat topic autocreation failed for '${cfg.heartbeatTopic}' (partitions=${cfg.topicAutoCreatePartitions}, rf=${cfg.topicAutoCreateReplicationFactor})", t)
+          }
+        } else {
+          throw new org.apache.kafka.connect.errors.ConnectException(s"Guard heartbeat topic '${cfg.heartbeatTopic}' does not exist and guard.topic.autocreate.enable=false")
+        }
+      } else {
+        logger.debug(s"[KafkaGuardSupport][${connectorTaskId.name}] Heartbeat topic '${cfg.heartbeatTopic}' already exists")
+      }
+    } catch {
+      case t: Throwable => logger.warn(s"[KafkaGuardSupport][${connectorTaskId.name}] Heartbeat topic check failed for '${cfg.heartbeatTopic}'", t)
+    } finally {
+      if (admin != null) try admin.close() catch { case _: Throwable => () }
+    }
+  }
+
+  private def topicExists(admin: AdminClient, topic: String): Boolean = {
+    val names = admin.listTopics().names().get(5, TimeUnit.SECONDS)
+    names.contains(topic)
+  }
+
+  protected def onCloseGuard(partitions: java.util.Collection[KafkaTopicPartition]): Unit = {
+    leaseGuard.foreach { lg =>
+      val it = partitions.iterator()
+      while (it.hasNext) {
+        val tp = it.next(); val pl = PartitionLease(tp.topic(), tp.partition())
+        if (heldLeases.contains(pl)) { lg.release(pl); heldLeases.remove(pl) }
+      }
+    }
+  }
+
+  protected def onStopGuard(): Unit = {
+    leaseGuard.foreach(_.shutdownAll())
+    leaseGuard = None
+    heldLeases.clear()
+  }
+
+  protected def preWriteHeartbeatGuard(): Unit = {
+    leaseGuard.foreach { lg => heldLeases.foreach(pl => lg.heartbeatNow(pl)) }
+  }
+}
+
+

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/guard/KafkaLeaseGuard.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/guard/KafkaLeaseGuard.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017-2025 Lenses.io Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lenses.streamreactor.connect.cloud.common.guard
+
+import java.util.Properties
+import java.util.concurrent.{ Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit }
+import java.util.concurrent.atomic.AtomicBoolean
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata }
+import org.apache.kafka.common.errors.{ ProducerFencedException, TimeoutException }
+import org.apache.kafka.common.serialization.{ ByteArraySerializer, StringSerializer }
+
+final case class PartitionLease(topic: String, partition: Int)
+
+class KafkaLeaseGuard(
+  bootstrapServers: String,
+  heartbeatTopic:   String,
+  heartbeatMs:      Long,
+  connectorName:    String,
+  baseClientProps:  java.util.Properties,
+) extends LazyLogging {
+
+  private case class Holder(
+    producer:        KafkaProducer[String, Array[Byte]],
+    scheduler:       ScheduledExecutorService,
+    task:            ScheduledFuture[_],
+    needCommitRetry: AtomicBoolean,
+  )
+
+  private val holders = scala.collection.concurrent.TrieMap[PartitionLease, Holder]()
+
+  private def transactionalId(pl: PartitionLease): String = s"lease.$connectorName.${pl.topic}.${pl.partition}"
+
+  private def newProducer(txId: String): KafkaProducer[String, Array[Byte]] = {
+    val props = new Properties()
+    props.putAll(baseClientProps)
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+    props.put(ProducerConfig.ACKS_CONFIG, "all")
+    props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
+    props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, txId)
+    new KafkaProducer[String, Array[Byte]](props)
+  }
+
+  private def performHeartbeat(producer: KafkaProducer[String, Array[Byte]], pl: PartitionLease, needCommitRetry: AtomicBoolean): Unit = {
+    try {
+      if (needCommitRetry.get()) {
+        retryOutstandingCommit(producer, pl, needCommitRetry)
+        if (needCommitRetry.get()) {
+          logger.debug(s"[KafkaLeaseGuard][$connectorName] Prior commit still unresolved for $pl; skipping heartbeat transaction this cycle")
+          return
+        }
+      }
+
+      producer.beginTransaction()
+      val key   = s"${pl.topic}-${pl.partition}"
+      val value = Array.emptyByteArray
+      val rec   = new ProducerRecord[String, Array[Byte]](heartbeatTopic, key, value)
+      producer.send(rec, (_: RecordMetadata, _: Exception) => ())
+      try {
+        producer.commitTransaction()
+        needCommitRetry.set(false)
+      } catch {
+        case _: TimeoutException =>
+          logger.warn(s"[KafkaLeaseGuard][$connectorName] commitTransaction timed out for $pl, will retry on next heartbeat")
+          needCommitRetry.set(true)
+      }
+    } catch {
+      case _: ProducerFencedException =>
+        val txId = transactionalId(pl)
+        logger.error(s"[KafkaLeaseGuard][$connectorName] Producer fenced for $pl (transactional.id=$txId). This task is no longer the active owner.")
+        try producer.close() catch { case _: Throwable => () }
+        release(pl)
+        throw new IllegalStateException(s"Fenced for $pl")
+      case e: IllegalStateException if e.getMessage != null && e.getMessage.contains("previous call to `commitTransaction` timed out") =>
+        logger.debug(s"[KafkaLeaseGuard][$connectorName] beginTransaction blocked due to prior commit timeout for $pl; retrying commit")
+        needCommitRetry.set(true)
+        retryOutstandingCommit(producer, pl, needCommitRetry)
+        ()
+    }
+  }
+
+  private def retryOutstandingCommit(
+    producer:        KafkaProducer[String, Array[Byte]],
+    pl:              PartitionLease,
+    needCommitRetry: AtomicBoolean,
+  ): Unit = {
+    if (!needCommitRetry.get()) return
+    try {
+      producer.commitTransaction()
+      needCommitRetry.set(false)
+      logger.debug(s"[KafkaLeaseGuard][$connectorName] Retried commitTransaction succeeded for $pl")
+    } catch {
+      case _: TimeoutException =>
+        logger.warn(s"[KafkaLeaseGuard][$connectorName] commitTransaction retry timed out for $pl; will retry on next cycle")
+        needCommitRetry.set(true)
+      case _: ProducerFencedException =>
+        val txId = transactionalId(pl)
+        logger.error(s"[KafkaLeaseGuard][$connectorName] Producer fenced while retrying commit for $pl (transactional.id=$txId)")
+        try producer.close() catch { case _: Throwable => () }
+        release(pl)
+        throw new IllegalStateException(s"Fenced during commit retry for $pl")
+    }
+  }
+
+  def acquire(pl: PartitionLease): Unit = {
+    val txId = transactionalId(pl)
+    val producer = newProducer(txId)
+    producer.initTransactions()
+    val scheduler = Executors.newSingleThreadScheduledExecutor()
+    val needCommitRetry = new AtomicBoolean(false)
+    val runnable: Runnable = () => {
+      try performHeartbeat(producer, pl, needCommitRetry)
+      catch {
+        case t: Throwable =>
+          if (holders.contains(pl)) {
+            release(pl)
+            throw t
+          }
+      }
+    }
+    val task: ScheduledFuture[_] = scheduler.scheduleAtFixedRate(runnable, 0L, Math.max(1L, heartbeatMs), TimeUnit.MILLISECONDS)
+    holders.put(pl, Holder(producer, scheduler, task, needCommitRetry)); ()
+  }
+
+  def heartbeatNow(pl: PartitionLease): Unit = {
+    holders.get(pl).foreach { h =>
+      val f = h.scheduler.submit((() => performHeartbeat(h.producer, pl, h.needCommitRetry)): Runnable)
+      f.get()
+    }
+  }
+
+  def release(pl: PartitionLease): Unit = {
+    holders.remove(pl).foreach { h =>
+      try h.task.cancel(true) catch { case _: Throwable => () }
+      try h.scheduler.shutdownNow() catch { case _: Throwable => () }
+      try h.producer.close() catch { case _: Throwable => () }
+    }
+  }
+
+  def shutdownAll(): Unit = {
+    holders.keySet.foreach(release)
+  }
+}

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/GuardSettings.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/GuardSettings.scala
@@ -1,0 +1,55 @@
+package io.lenses.streamreactor.connect.cloud.common.sink.config
+
+import io.lenses.streamreactor.common.config.base.traits.WithConnectorPrefix
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
+
+trait GuardConfigKeys extends WithConnectorPrefix {
+  val GUARD_ENABLE                              = s"$connectorPrefix.guard.enable"
+  val GUARD_BOOTSTRAP_SERVERS                   = s"$connectorPrefix.guard.bootstrap.servers"
+  val GUARD_HEARTBEAT_TOPIC                     = s"$connectorPrefix.guard.heartbeat.topic"
+  val GUARD_HEARTBEAT_MS                        = s"$connectorPrefix.guard.heartbeat.ms"
+  val GUARD_TOPIC_AUTOCREATE_ENABLE             = s"$connectorPrefix.guard.topic.autocreate.enable"
+  val GUARD_TOPIC_AUTOCREATE_PARTITIONS         = s"$connectorPrefix.guard.topic.autocreate.partitions"
+  val GUARD_TOPIC_AUTOCREATE_REPLICATION_FACTOR = s"$connectorPrefix.guard.topic.autocreate.replication.factor"
+
+  private val GUARD_ENABLE_DOC = "Enable Kafka-based guard to fence duplicate active tasks"
+  private val GUARD_BOOTSTRAP_DOC = "Bootstrap servers for guard. Other client settings may be set via guard.client.*"
+  private val GUARD_HEARTBEAT_TOPIC_DOC = "Topic used to write guard heartbeats (use compacted topic)"
+  private val GUARD_HEARTBEAT_MS_DOC = "Heartbeat interval in milliseconds"
+  private val GUARD_AUTOCREATE_ENABLE_DOC = "If true, auto-create the guard heartbeat topic when missing (cleanup.policy=compact)."
+  private val GUARD_AUTOCREATE_PARTITIONS_DOC = "Partitions for auto-created heartbeat topic. 1 is sufficient for fencing."
+  private val GUARD_AUTOCREATE_RF_DOC = "Replication factor for auto-created heartbeat topic. Default 1 for portability; recommend 3 in production."
+
+
+  final val DEFAULTS: Map[String, Any] = Map(
+    GUARD_ENABLE -> false,
+    GUARD_BOOTSTRAP_SERVERS -> null,
+    GUARD_HEARTBEAT_TOPIC -> s"${connectorPrefix.replace('.', '-')}-sink-guard-heartbeat",
+    GUARD_HEARTBEAT_MS -> 10000L,
+    GUARD_TOPIC_AUTOCREATE_ENABLE -> true,
+    GUARD_TOPIC_AUTOCREATE_PARTITIONS -> 1,
+    GUARD_TOPIC_AUTOCREATE_REPLICATION_FACTOR -> 1.toShort,
+  )
+
+  def addGuardSettingsToConfigDef(configDef: ConfigDef): ConfigDef =
+    configDef
+      .define(GUARD_ENABLE, Type.BOOLEAN, DEFAULTS(GUARD_ENABLE), Importance.HIGH, GUARD_ENABLE_DOC)
+      .define(GUARD_BOOTSTRAP_SERVERS, Type.STRING, DEFAULTS(GUARD_BOOTSTRAP_SERVERS), Importance.HIGH, GUARD_BOOTSTRAP_DOC)
+      .define(GUARD_HEARTBEAT_TOPIC, Type.STRING, DEFAULTS(GUARD_HEARTBEAT_TOPIC), Importance.LOW, GUARD_HEARTBEAT_TOPIC_DOC)
+      .define(GUARD_HEARTBEAT_MS, Type.LONG, DEFAULTS(GUARD_HEARTBEAT_MS), Importance.LOW, GUARD_HEARTBEAT_MS_DOC)
+      .define(GUARD_TOPIC_AUTOCREATE_ENABLE, Type.BOOLEAN, DEFAULTS(GUARD_TOPIC_AUTOCREATE_ENABLE), Importance.LOW, GUARD_AUTOCREATE_ENABLE_DOC)
+      .define(GUARD_TOPIC_AUTOCREATE_PARTITIONS, Type.INT, DEFAULTS(GUARD_TOPIC_AUTOCREATE_PARTITIONS), Importance.LOW, GUARD_AUTOCREATE_PARTITIONS_DOC)
+      .define(GUARD_TOPIC_AUTOCREATE_REPLICATION_FACTOR, Type.SHORT, DEFAULTS(GUARD_TOPIC_AUTOCREATE_REPLICATION_FACTOR), Importance.LOW, GUARD_AUTOCREATE_RF_DOC)
+
+}
+
+trait GuardSettings extends io.lenses.streamreactor.common.config.base.traits.BaseSettings with GuardConfigKeys {
+  def getGuardEnable: Boolean = getBoolean(GUARD_ENABLE)
+
+  def getGuardBootstrapServersOpt: Option[String] = Option(getString(GUARD_BOOTSTRAP_SERVERS)).filter(_.trim.nonEmpty)
+
+  def getGuardHeartbeatTopic: String = getString(GUARD_HEARTBEAT_TOPIC)
+
+  def getGuardHeartbeatMs: Long = getLong(GUARD_HEARTBEAT_MS)
+}

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfig.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfig.scala
@@ -55,6 +55,10 @@ object GCPStorageSinkConfig extends PropsToConfigConverter[GCPStorageSinkConfig]
       logMetrics              = gcpConfigDefBuilder.getBoolean(LOG_METRICS_CONFIG)
       schemaChangeDetector    = gcpConfigDefBuilder.schemaChangeDetector()
       useLatestSchemaForWrite = gcpConfigDefBuilder.getEnableLatestSchemaOptimization()
+      guardEnable             = gcpConfigDefBuilder.getGuardEnable
+      guardBootstrap          = gcpConfigDefBuilder.getGuardBootstrapServersOpt
+      guardTopic              = gcpConfigDefBuilder.getGuardHeartbeatTopic
+      guardMs                 = gcpConfigDefBuilder.getGuardHeartbeatMs
     } yield GCPStorageSinkConfig(
       gcpConnectionSettings,
       sinkBucketOptions,
@@ -67,6 +71,10 @@ object GCPStorageSinkConfig extends PropsToConfigConverter[GCPStorageSinkConfig]
       schemaChangeDetector        = schemaChangeDetector,
       skipNullValues              = gcpConfigDefBuilder.skipNullValues(),
       latestSchemaForWriteEnabled = useLatestSchemaForWrite,
+      guardEnable                 = guardEnable,
+      guardBootstrapServers       = guardBootstrap,
+      guardHeartbeatTopic         = guardTopic,
+      guardHeartbeatMs            = guardMs,
     )
   }
 
@@ -84,4 +92,8 @@ case class GCPStorageSinkConfig(
   schemaChangeDetector:        SchemaChangeDetector,
   skipNullValues:              Boolean,
   latestSchemaForWriteEnabled: Boolean,
+  guardEnable:                 Boolean,
+  guardBootstrapServers:       Option[String],
+  guardHeartbeatTopic:         String,
+  guardHeartbeatMs:            Long,
 ) extends CloudSinkConfig[GCPConnectionConfig]

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageSinkConfigDefBuilder.scala
@@ -17,6 +17,7 @@ package io.lenses.streamreactor.connect.gcp.storage.sink.config
 
 import io.lenses.streamreactor.common.config.base.traits._
 import io.lenses.streamreactor.connect.cloud.common.sink.config.CloudSinkConfigDefBuilder
+import io.lenses.streamreactor.connect.cloud.common.sink.config.GuardSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.GCPSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.GCPConfigSettings
 import io.lenses.streamreactor.connect.gcp.storage.config.UploadSettings
@@ -26,6 +27,7 @@ import scala.jdk.CollectionConverters.MapHasAsScala
 case class GCPStorageSinkConfigDefBuilder(props: Map[String, AnyRef])
     extends BaseConfig(GCPConfigSettings.CONNECTOR_PREFIX, GCPStorageSinkConfigDef.config, props)
     with CloudSinkConfigDefBuilder
+    with GuardSettings
     with ErrorPolicySettings
     with RetryConfigSettings
     with GCPSettings


### PR DESCRIPTION
### Problem
As said in [cdc4e46](https://github.com/lensesio/stream-reactor/commit/cdc4e46a65306f2a26473284cc9577bb00a2d419), Kafka Connect can incorrectly run multiple tasks for the same topic/partition pair. Commit cdc4e46 introduced the ETag-based Upload-Copy-Delete flow to handle this. This works but **triples S3 API costs**.
For high-volume deployments, this makes the connector too expensive to run.

### Solution
Use Kafka transactions for distributed locking instead of the expensive upload flow.
Each task gets a unique transactional producer ID per topic/partition. Tasks send heartbeats to a compacted topic. If two tasks try to write to the same partition, Kafka's transaction coordinator automatically fences the older one.

### Config
The guard is disabled by default and can be enabled with:
```
# Enable guard functionality
connect.s3.guard.enable=true

# Kafka cluster for guard operations (required when enabled)
connect.s3.guard.bootstrap.servers=localhost:9092

# Guard heartbeat configuration (optional)
connect.s3.guard.heartbeat.topic=s3-sink-heartbeat
connect.s3.guard.heartbeat.ms=10000

# Topic auto-creation (optional)
connect.s3.guard.topic.autocreate.enable=true
connect.s3.guard.topic.autocreate.partitions=1
connect.s3.guard.topic.autocreate.replication.factor=3
```
Additional Kafka client properties can be configured using the `guard.client.*` prefix.

These changes allow removing the ETag-based Upload-Copy-Delete flow entirely, restoring direct uploads with full safety guarantees.