### PR TITLE
Generate kcql autocompletion examples

### DIFF
--- a/docs/kcql-autocomplete-examples.json
+++ b/docs/kcql-autocomplete-examples.json
@@ -7,6 +7,7 @@
       "id": "aws-s3-sink",
       "label": "AWS S3 Sink",
       "connectorClass": "io.lenses.streamreactor.connect.aws.s3.sink.S3SinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Partitioned Parquet landing zone",
@@ -49,6 +50,7 @@
       "id": "aws-s3-source",
       "label": "AWS S3 Source",
       "connectorClass": "io.lenses.streamreactor.connect.aws.s3.source.S3SourceConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Avro export replay",
@@ -76,6 +78,7 @@
       "id": "gcp-storage-sink",
       "label": "GCP Storage Sink",
       "connectorClass": "io.lenses.streamreactor.connect.gcp.storage.sink.GCPStorageSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "JSON landing zone",
@@ -113,6 +116,7 @@
       "id": "azure-datalake-sink",
       "label": "Azure Data Lake Sink",
       "connectorClass": "io.lenses.streamreactor.connect.datalake.sink.DatalakeSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Parquet landing with auto folders",
@@ -135,6 +139,7 @@
       "id": "azure-cosmosdb-sink",
       "label": "Azure Cosmos DB Sink",
       "connectorClass": "io.lenses.streamreactor.connect.azure.cosmosdb.sink.CosmosDbSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Auto-create collection",
@@ -162,6 +167,7 @@
       "id": "cassandra-sink",
       "label": "Cassandra Sink",
       "connectorClass": "io.lenses.streamreactor.connect.cassandra.sink.CassandraSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Hot data with TTL",
@@ -184,6 +190,7 @@
       "id": "cassandra-source",
       "label": "Cassandra Source",
       "connectorClass": "io.lenses.streamreactor.connect.cassandra.source.CassandraSourceConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Timestamp increments",
@@ -211,6 +218,7 @@
       "id": "elastic-sink",
       "label": "Elasticsearch 6/7 Sink",
       "connectorClass": "io.lenses.streamreactor.connect.elastic7.ElasticSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Auto-create daily index",
@@ -233,6 +241,7 @@
       "id": "mongodb-sink",
       "label": "MongoDB Sink",
       "connectorClass": "io.lenses.streamreactor.connect.mongodb.sink.MongoSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Simple collection copy",
@@ -255,6 +264,7 @@
       "id": "mqtt-source",
       "label": "MQTT Source",
       "connectorClass": "io.lenses.streamreactor.connect.mqtt.source.MqttSourceConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Wildcard Avro converter",
@@ -277,6 +287,7 @@
       "id": "mqtt-sink",
       "label": "MQTT Sink",
       "connectorClass": "io.lenses.streamreactor.connect.mqtt.sink.MqttSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Static destination",
@@ -299,6 +310,7 @@
       "id": "jms-source",
       "label": "JMS Source",
       "connectorClass": "io.lenses.streamreactor.connect.jms.source.JMSSourceConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Queue to Kafka",
@@ -321,6 +333,7 @@
       "id": "jms-sink",
       "label": "JMS Sink",
       "connectorClass": "io.lenses.streamreactor.connect.jms.sink.JMSSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Proto converter",
@@ -343,6 +356,7 @@
       "id": "azure-servicebus-source",
       "label": "Azure Service Bus Source",
       "connectorClass": "io.lenses.streamreactor.connect.azure.servicebus.source.AzureServiceBusSourceConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Queue to Kafka",
@@ -360,6 +374,7 @@
       "id": "azure-servicebus-sink",
       "label": "Azure Service Bus Sink",
       "connectorClass": "io.lenses.streamreactor.connect.azure.servicebus.sink.AzureServiceBusSinkConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Queue sink with batching",
@@ -377,6 +392,7 @@
       "id": "azure-eventhubs-source",
       "label": "Azure Event Hubs Source",
       "connectorClass": "io.lenses.streamreactor.connect.azure.eventhubs.source.AzureEventHubsSourceConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Notifications mirror",
@@ -394,6 +410,7 @@
       "id": "gcp-pubsub-source",
       "label": "GCP Pub/Sub Source",
       "connectorClass": "io.lenses.streamreactor.connect.gcp.pubsub.source.GCPPubSubSourceConnector",
+      "version": "9.1-SNAPSHOT",
       "examples": [
         {
           "name": "Fully qualified subscription",


### PR DESCRIPTION
Add a comprehensive KCQL autocomplete catalogue for Monaco editor, providing realistic examples and descriptions for various Stream Reactor connectors.

---
<a href="https://cursor.com/background-agent?bcId=bc-191ef597-17d9-400b-9474-e8bffa778668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-191ef597-17d9-400b-9474-e8bffa778668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

