### PR TITLE
fix(azure-datalake): correct tuple order in getBlobAsStringAndEtag

### DIFF
--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterface.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterface.scala
@@ -343,7 +343,7 @@ class DatalakeStorageInterface(connectorTaskId: ConnectorTaskId, client: DataLak
             null,
             Context.NONE,
           )
-          (resp.getDeserializedHeaders.getETag, new String(baos.toByteArray))
+          (new String(baos.toByteArray), resp.getDeserializedHeaders.getETag)
       }
     }.toEither.leftMap {
       case ex: DataLakeStorageException if ex.getStatusCode == 404 =>

--- a/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
+++ b/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
@@ -532,7 +532,7 @@ class DatalakeStorageInterfaceTest
     }
     val result = storageInterface.getBlobAsStringAndEtag(bucket, path)
 
-    result.value should be((expectedEtag, expectedContent))
+    result.value should be((expectedContent, expectedEtag))
   }
 
   "writeStringToFile" should "upload the data string to the specified path when successful" in {


### PR DESCRIPTION
The method was returning (eTag, content) but the StorageInterface contract expects (content, eTag) https://github.com/lensesio/stream-reactor/blob/754cf60a3ca708264d7f4bbb253e2234ebdc196f/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/storage/StorageInterface.scala#L80

This caused the JSON parser to attempt parsing the ETag string as JSON when reading lock files, resulting in "expected whitespace or eof" errors on connector restart and crash of the connector.