### PR TITLE
provide a custom file namer

### DIFF
--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/sink/config/S3SinkConfigDefBuilderTest.scala
@@ -98,7 +98,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
     )
 
     config.CloudSinkBucketOptions(connectorTaskId, S3SinkConfigDefBuilder(props)).value.map(_.dataStorage) should be(
-      List(DataStorageSettings(true, true, true, false, false)),
+      List(DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false, customNamerFactory = None)),
     )
 
   }
@@ -122,7 +122,9 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
     )
 
     config.CloudSinkBucketOptions(connectorTaskId, S3SinkConfigDefBuilder(props)).value.map(_.dataStorage) should be(
-      List(DataStorageSettings(true, true, true, false, false), DataStorageSettings(true, true, true, false, true)),
+      List(
+        DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false, None),
+        DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = true, None)),
     )
 
   }
@@ -194,7 +196,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
     )
 
     config.CloudSinkBucketOptions(connectorTaskId, S3SinkConfigDefBuilder(props)).value.map(_.dataStorage) should be(
-      List(DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false)),
+      List(DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false, customNamerFactory = None)),
     )
   }
 
@@ -204,7 +206,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
     )
 
     config.CloudSinkBucketOptions(connectorTaskId, S3SinkConfigDefBuilder(props)).value.map(_.dataStorage) should be(
-      List(DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false)),
+      List(DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false, customNamerFactory = None)),
     )
   }
 
@@ -214,7 +216,7 @@ class S3SinkConfigDefBuilderTest extends AnyFlatSpec with MockitoSugar with Matc
     )
 
     config.CloudSinkBucketOptions(connectorTaskId, S3SinkConfigDefBuilder(props)).value.map(_.dataStorage) should be(
-      List(DataStorageSettings(envelope = true, key = true, value = true, metadata = true, headers = true)),
+      List(DataStorageSettings(envelope = true, key = true, value = true, metadata = true, headers = true, customNamerFactory = None)),
     )
   }
 

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/DataStorageSettings.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/DataStorageSettings.scala
@@ -21,6 +21,7 @@ import cats.implicits.catsSyntaxTuple2Semigroupal
 import cats.implicits.catsSyntaxValidatedId
 import io.lenses.streamreactor.connect.cloud.common.config.kcqlprops.PropsKeyEntry
 import io.lenses.streamreactor.connect.cloud.common.config.kcqlprops.PropsKeyEnum
+import io.lenses.streamreactor.connect.cloud.common.sink.naming.FileNamerFactory
 import io.lenses.streamreactor.connect.config.kcqlprops.KcqlProperties
 import org.apache.kafka.common.config.ConfigException
 
@@ -34,23 +35,26 @@ import org.apache.kafka.common.config.ConfigException
  * @param headers - If enabled it stores the headers of the Kafka message
  */
 case class DataStorageSettings(
-  envelope: Boolean,
-  key:      Boolean,
-  value:    Boolean,
-  metadata: Boolean,
-  headers:  Boolean,
+  envelope:            Boolean,
+  key:                 Boolean,
+  value:               Boolean,
+  metadata:            Boolean,
+  headers:             Boolean,
+  customNamerFactory:  Option[FileNamerFactory],
 ) {
   def hasEnvelope: Boolean = envelope
 }
 
 object DataStorageSettings {
 
-  val StoreEnvelopeKey  = "store.envelope"
-  private val KeyPrefix = "store.envelope.fields"
-  val StoreKeyKey       = s"$KeyPrefix.key"
-  val StoreHeadersKey   = s"$KeyPrefix.headers"
-  val StoreValueKey     = s"$KeyPrefix.value"
-  val StoreMetadataKey  = s"$KeyPrefix.metadata"
+  val StoreEnvelopeKey     = "store.envelope"
+  val StoreFileNamer       = "store.file.namer"
+  val StoreFileNamerParam  = "store.file.namer.param"
+  private val KeyPrefix    = "store.envelope.fields"
+  val StoreKeyKey          = s"$KeyPrefix.key"
+  val StoreHeadersKey      = s"$KeyPrefix.headers"
+  val StoreValueKey        = s"$KeyPrefix.value"
+  val StoreMetadataKey     = s"$KeyPrefix.metadata"
   val AllEnvelopeFields: Seq[String] = List(
     PropsKeyEnum.StoreEnvelopeKey,
     PropsKeyEnum.StoreEnvelopeValue,
@@ -61,16 +65,17 @@ object DataStorageSettings {
   private val DefaultFieldsValue   = true
 
   val Default: DataStorageSettings = DataStorageSettings(
-    envelope = DefaultEnvelopeValue,
-    key      = DefaultFieldsValue,
-    value    = DefaultFieldsValue,
-    metadata = DefaultFieldsValue,
-    headers  = DefaultFieldsValue,
+    envelope           = DefaultEnvelopeValue,
+    key                = DefaultFieldsValue,
+    value              = DefaultFieldsValue,
+    metadata           = DefaultFieldsValue,
+    headers            = DefaultFieldsValue,
+    customNamerFactory = None,
   )
 
   def disabled: DataStorageSettings = Default
   def enabled: DataStorageSettings =
-    DataStorageSettings(envelope = true, key = true, value = true, metadata = true, headers = true)
+    DataStorageSettings(envelope = true, key = true, value = true, metadata = true, headers = true, customNamerFactory = None)
 
   def from(properties: KcqlProperties[PropsKeyEntry, PropsKeyEnum.type]): Either[ConfigException, DataStorageSettings] =
     for {
@@ -84,12 +89,14 @@ object DataStorageSettings {
           //if no envelope default
           Default.asRight[ConfigException]
         } else {
+          val customNamerFactory:Option[FileNamerFactory] =properties.getCustomValue(PropsKeyEnum.StoreFileNamer, PropsKeyEnum.StoreFileNamerParam)
           val setting = DataStorageSettings(
-            envelope = envelope,
-            key      = key,
-            value    = value,
-            metadata = metadata,
-            headers  = headers,
+            envelope           = envelope,
+            key                = key,
+            value              = value,
+            metadata           = metadata,
+            headers            = headers,
+            customNamerFactory = customNamerFactory
           )
 
           (

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/kcqlprops/PropsKeyEnum.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/kcqlprops/PropsKeyEnum.scala
@@ -46,6 +46,8 @@ object PropsKeyEnum extends Enum[PropsKeyEntry] {
   case object StoreEnvelopeHeaders  extends PropsKeyEntry(DataStorageSettings.StoreHeadersKey)
   case object StoreEnvelopeValue    extends PropsKeyEntry(DataStorageSettings.StoreValueKey)
   case object StoreEnvelopeMetadata extends PropsKeyEntry(DataStorageSettings.StoreMetadataKey)
+  case object StoreFileNamer        extends PropsKeyEntry(DataStorageSettings.StoreFileNamer)
+  case object StoreFileNamerParam   extends PropsKeyEntry(DataStorageSettings.StoreFileNamerParam)
 
   case object PaddingLength extends PropsKeyEntry("padding.length")
 

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkBucketOptions.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/config/CloudSinkBucketOptions.scala
@@ -37,6 +37,8 @@ import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingS
 import io.lenses.streamreactor.connect.cloud.common.sink.naming._
 import org.apache.kafka.common.config.ConfigException
 
+import scala.util.Try
+
 object CloudSinkBucketOptions extends LazyLogging {
 
   val WithFlushErrorMessage = s"""
@@ -113,21 +115,26 @@ object CloudSinkBucketOptions extends LazyLogging {
     partitionSelection: PartitionSelection,
     paddingService:     PaddingService,
     suffix:             Option[String],
-  ): Either[Throwable, FileNamer] =
-    if (partitionSelection.isCustom) {
-      new TopicPartitionOffsetFileNamer(
-        paddingService.padderFor("partition"),
-        paddingService.padderFor("offset"),
-        fileExtension,
-        suffix,
-      ).asRight
-    } else {
-      new OffsetFileNamer(
-        paddingService.padderFor("offset"),
-        fileExtension,
-        suffix,
-      ).asRight
-    }
+  ): Either[Throwable, FileNamer] = {
+    val config = FileNamerConfig(
+      partitionPaddingStrategy = paddingService.padderFor("partition"),
+      offsetPaddingStrategy = paddingService.padderFor("offset"),
+      extension = fileExtension,
+      suffix = suffix,
+    )
+    Try {
+      storageSettings.customNamerFactory match {
+        case Some(factory) =>
+          factory.createFileNamer(config)
+        case None =>
+          if (partitionSelection.isCustom) {
+            new TopicPartitionOffsetFileNamer(config)
+          } else {
+            new OffsetFileNamer(config)
+          }
+      }
+    }.toEither
+  }
 
   private def validateWithFlush(kcql: Kcql): Either[Throwable, Unit] = {
     val sql = kcql.getQuery.toUpperCase()

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamer.scala
@@ -118,12 +118,18 @@ class CloudKeyNamer(
     partitionValues:         Map[PartitionField, String],
     earliestRecordTimestamp: Long,
     latestRecordTimestamp:   Long,
-  ): Either[FatalCloudSinkError, CloudLocation] =
+  ): Either[FatalCloudSinkError, CloudLocation] = {
+    val params = FileNamerParams(
+      topicPartitionOffset,
+      earliestRecordTimestamp,
+      latestRecordTimestamp,
+    )
     Try(
       bucketAndPrefix.withPath(
-        s"${prefix(bucketAndPrefix)}${buildPartitionPrefix(partitionValues)}/${fileNamer.fileName(topicPartitionOffset, earliestRecordTimestamp, latestRecordTimestamp)}",
+        s"${prefix(bucketAndPrefix)}${buildPartitionPrefix(partitionValues)}/${fileNamer.fileName(params)}",
       ),
     ).toEither.left.map(ex => FatalCloudSinkError(ex.getMessage, topicPartitionOffset.toTopicPartition))
+  }
 
   override def processPartitionValues(
     messageDetail:  MessageDetail,

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/config/DataStorageSettingsTests.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/config/DataStorageSettingsTests.scala
@@ -41,11 +41,12 @@ class DataStorageSettingsTests extends AnyFunSuite with Matchers with EitherValu
     val properties      = Map(DataStorageSettings.StoreEnvelopeKey -> "true")
     val storageSettings = DataStorageSettings.from(toKcqlProps(properties))
     storageSettings shouldBe Right(DataStorageSettings(
-      envelope = true,
-      key      = true,
-      value    = true,
-      metadata = true,
-      headers  = true,
+      envelope           = true,
+      key                = true,
+      value              = true,
+      metadata           = true,
+      headers            = true,
+      customNamerFactory = None
     ))
   }
 
@@ -82,11 +83,12 @@ class DataStorageSettingsTests extends AnyFunSuite with Matchers with EitherValu
     )
     val storageSettings = DataStorageSettings.from(toKcqlProps(properties))
     storageSettings shouldBe Right(DataStorageSettings(
-      envelope = true,
-      key      = true,
-      value    = false,
-      metadata = false,
-      headers  = false,
+      envelope           = true,
+      key                = true,
+      value              = false,
+      metadata           = false,
+      headers            = false,
+      customNamerFactory = None
     ))
   }
 
@@ -105,6 +107,7 @@ class DataStorageSettingsTests extends AnyFunSuite with Matchers with EitherValu
       value    = false,
       metadata = true,
       headers  = false,
+      customNamerFactory = None,
     ))
   }
   test("headers enabled") {
@@ -117,11 +120,12 @@ class DataStorageSettingsTests extends AnyFunSuite with Matchers with EitherValu
     )
     val storageSettings = DataStorageSettings.from(toKcqlProps(properties))
     storageSettings shouldBe Right(DataStorageSettings(
-      envelope = true,
-      key      = false,
-      value    = false,
-      metadata = false,
-      headers  = true,
+      envelope           = true,
+      key                = false,
+      value              = false,
+      metadata           = false,
+      headers            = true,
+      customNamerFactory = None,
     ))
   }
   test("all enabled") {
@@ -134,11 +138,12 @@ class DataStorageSettingsTests extends AnyFunSuite with Matchers with EitherValu
     )
     val storageSettings = DataStorageSettings.from(toKcqlProps(properties))
     storageSettings shouldBe Right(DataStorageSettings(
-      envelope = true,
-      key      = true,
-      value    = true,
-      metadata = true,
-      headers  = true,
+      envelope           = true,
+      key                = true,
+      value              = true,
+      metadata           = true,
+      headers            = true,
+      customNamerFactory = None
     ))
   }
   test("invalid envelope value") {

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamerTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/CloudKeyNamerTest.scala
@@ -26,9 +26,7 @@ import io.lenses.streamreactor.connect.cloud.common.sink.SinkError
 import io.lenses.streamreactor.connect.cloud.common.sink.config.PartitionDisplay.Values
 import io.lenses.streamreactor.connect.cloud.common.sink.config.PartitionSelection.defaultPartitionSelection
 import io.lenses.streamreactor.connect.cloud.common.sink.config._
-import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.LeftPadPaddingStrategy
-import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingService
-import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.PaddingStrategy
+import io.lenses.streamreactor.connect.cloud.common.sink.config.padding.{LeftPadPaddingStrategy, NoOpPaddingStrategy, PaddingService, PaddingStrategy}
 import io.lenses.streamreactor.connect.cloud.common.sink.conversion.NullSinkData
 import io.lenses.streamreactor.connect.cloud.common.sink.conversion.StringSinkData
 import io.lenses.streamreactor.connect.cloud.common.utils.SampleData
@@ -70,7 +68,11 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
       PartitionSelection(isCustom = false, List(HeaderPartitionField(PartitionNamePath("h"))), Values)
 
     val fileNamer: FileNamer =
-      new OffsetFileNamer(paddingStrategy, JsonFormatSelection.extension, None)
+      new OffsetFileNamer(FileNamerConfig(
+        partitionPaddingStrategy = NoOpPaddingStrategy,
+        offsetPaddingStrategy    = paddingStrategy,
+        extension                = JsonFormatSelection.extension,
+        suffix                   = None))
 
     val keyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
     val either: Either[SinkError, Map[PartitionField, String]] = keyNamer.processPartitionValues(
@@ -93,7 +95,7 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
     val stagingDirectory = Files.createTempDirectory("myTempDir").toFile
 
     val fileNamer: FileNamer =
-      new OffsetFileNamer(paddingStrategy, JsonFormatSelection.extension, None)
+      new OffsetFileNamer(FileNamerConfig(NoOpPaddingStrategy, paddingStrategy, JsonFormatSelection.extension, None))
     val s3KeyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
 
     val result =
@@ -108,7 +110,7 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
   test("should generate the correct staging file path") {
     val stagingDirectory = Files.createTempDirectory("myTempDir").toFile
     val fileNamer: FileNamer =
-      new OffsetFileNamer(paddingStrategy, JsonFormatSelection.extension, None)
+      new OffsetFileNamer(FileNamerConfig(NoOpPaddingStrategy, paddingStrategy, JsonFormatSelection.extension, None))
     val s3KeyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
 
     val result =
@@ -122,7 +124,7 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
 
   test("should write to the root of the bucket with no prefix") {
     val fileNamer: FileNamer =
-      new OffsetFileNamer(paddingStrategy, JsonFormatSelection.extension, None)
+      new OffsetFileNamer(FileNamerConfig(NoOpPaddingStrategy, paddingStrategy, JsonFormatSelection.extension, None))
     val s3KeyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
 
     val result = s3KeyNamer.value(bucketNoPrefix, topicPartition, partitionValues, 0L, 10L)
@@ -132,7 +134,7 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
 
   test("should generate the correct final S3 location for v1 OffsetFileNamerV1 format") {
     val fileNamer: FileNamer =
-      new OffsetFileNamer(paddingStrategy, JsonFormatSelection.extension, None)
+      new OffsetFileNamer(FileNamerConfig(NoOpPaddingStrategy, paddingStrategy, JsonFormatSelection.extension, None))
     val s3KeyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
 
     val result = s3KeyNamer.value(bucketAndPrefix, topicPartition, partitionValues, 101L, 9999L)
@@ -142,7 +144,7 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
 
   test("should generate the correct final S3 location for TopicPartitionOffsetFileNamer format") {
     val fileNamer: FileNamer =
-      new TopicPartitionOffsetFileNamer(paddingStrategy, paddingStrategy, JsonFormatSelection.extension, None)
+      new TopicPartitionOffsetFileNamer(FileNamerConfig(paddingStrategy, paddingStrategy, JsonFormatSelection.extension, None))
     val s3KeyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
 
     val result = s3KeyNamer.value(bucketAndPrefix, topicPartition, partitionValues, 101L, 1000L)
@@ -153,7 +155,7 @@ class CloudKeyNamerTest extends AnyFunSuite with Matchers with OptionValues with
   test("should generate the correct final S3 location for TopicPartitionOffsetFileNamer format including prefix") {
     val prefix = "-my-suffix"
     val fileNamer: FileNamer =
-      new TopicPartitionOffsetFileNamer(paddingStrategy, paddingStrategy, JsonFormatSelection.extension, Some(prefix))
+      new TopicPartitionOffsetFileNamer(FileNamerConfig(paddingStrategy, paddingStrategy, JsonFormatSelection.extension, Some(prefix)))
     val s3KeyNamer = CloudKeyNamer(formatSelection, partitionSelection, fileNamer, paddingService)
 
     val result = s3KeyNamer.value(bucketAndPrefix, topicPartition, partitionValues, 101L, 1000L)

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/FileNamerTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/naming/FileNamerTest.scala
@@ -25,29 +25,30 @@ class FileNamerTest extends AnyFunSuite with Matchers {
   private val paddingStrategy      = LeftPad.toPaddingStrategy(5, '0')
   private val topicPartitionOffset = Topic("topic").withPartition(9).atOffset(81)
 
+  val config = FileNamerConfig(
+    partitionPaddingStrategy = paddingStrategy,
+    offsetPaddingStrategy    = paddingStrategy,
+    extension                = extension,
+    suffix                   = None,
+  )
   test("OffsetFileNamer.fileName should generate the correct file name") {
 
-    new OffsetFileNamer(paddingStrategy, extension, None).fileName(topicPartitionOffset,
-                                                                   1L,
-                                                                   9L,
+    new OffsetFileNamer(config)
+      .fileName(FileNamerParams(topicPartitionOffset, 1L, 9L)
     ) shouldEqual "00081_1_9.avro"
-    new OffsetFileNamer(paddingStrategy, extension, Some("my-suffix")).fileName(topicPartitionOffset,
-                                                                                1L,
-                                                                                9L,
+    new OffsetFileNamer(config.copy(suffix = Some("my-suffix")))
+      .fileName(FileNamerParams(topicPartitionOffset, 1L, 9L)
     ) shouldEqual "00081_1_9my-suffix.avro"
   }
 
   test("TopicPartitionOffsetFileNamer.fileName should generate the correct file name") {
 
-    new TopicPartitionOffsetFileNamer(paddingStrategy, paddingStrategy, extension, None).fileName(topicPartitionOffset,
-                                                                                                  0L,
-                                                                                                  0L,
+    new TopicPartitionOffsetFileNamer(config)
+      .fileName(FileNamerParams(topicPartitionOffset,0L, 0L)
     ) shouldEqual "topic(00009_00081).avro"
 
-    new TopicPartitionOffsetFileNamer(paddingStrategy, paddingStrategy, extension, Some("mine")).fileName(
-      topicPartitionOffset,
-      0L,
-      0L,
+    new TopicPartitionOffsetFileNamer(config.copy(suffix = Some("mine")))
+      .fileName(FileNamerParams(topicPartitionOffset, 0L, 0L)
     ) shouldEqual "topic(00009_00081)mine.avro"
   }
 }

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/transformers/DataSchemaBuilderTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/transformers/DataSchemaBuilderTest.scala
@@ -33,7 +33,7 @@ import java.time.Instant
 class DataSchemaBuilderTest extends AnyFunSuite with Matchers {
   test("create envelope schema containing Key, Values, Headers, and Metadata") {
     val storageSettings =
-      DataStorageSettings(envelope = true, value = true, key = true, metadata = true, headers = true)
+      DataStorageSettings(envelope = true, value = true, key = true, metadata = true, headers = true, customNamerFactory = None)
 
     val ts = Instant.now()
     val message = MessageDetail(
@@ -71,7 +71,7 @@ class DataSchemaBuilderTest extends AnyFunSuite with Matchers {
 
   test("create envelope schema containing Key, Values and Metadata") {
     val storageSettings =
-      DataStorageSettings(envelope = true, value = true, key = true, metadata = true, headers = false)
+      DataStorageSettings(envelope = true, value = true, key = true, metadata = true, headers = false, customNamerFactory = None)
     val ts = Instant.now()
     val message = MessageDetail(
       StringSinkData("key", Some(Schema.STRING_SCHEMA)),
@@ -105,7 +105,7 @@ class DataSchemaBuilderTest extends AnyFunSuite with Matchers {
 
   test("create envelope schema containing  Values and Metadata") {
     val storageSettings =
-      DataStorageSettings(key = false, metadata = true, headers = false, envelope = true, value = true)
+      DataStorageSettings(key = false, metadata = true, headers = false, envelope = true, value = true, customNamerFactory = None)
     val ts = Instant.now()
     val message = MessageDetail(
       StringSinkData("key", Some(Schema.STRING_SCHEMA)),

--- a/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageGCPStorageSinkConfigDefBuilderTest.scala
+++ b/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/sink/config/GCPStorageGCPStorageSinkConfigDefBuilderTest.scala
@@ -106,7 +106,7 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
     CloudSinkBucketOptions(connectorTaskId, GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
-        value.map(_.dataStorage) should be(List(DataStorageSettings(true, true, true, false, false)))
+        value.map(_.dataStorage) should be(List(DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false, customNamerFactory = None)))
     }
   }
 
@@ -133,8 +133,8 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
       case Right(value) =>
         value.map(_.dataStorage) should be(
           List(
-            DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false),
-            DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = true),
+            DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = false, customNamerFactory = None),
+            DataStorageSettings(envelope = true, key = true, value = true, metadata = false, headers = true, customNamerFactory = None),
           ),
         )
     }
@@ -216,11 +216,12 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
     CloudSinkBucketOptions(connectorTaskId, GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
-        value.map(_.dataStorage) should be(List(DataStorageSettings(envelope = true,
-                                                                    key      = true,
-                                                                    value    = true,
-                                                                    metadata = false,
-                                                                    headers  = false,
+        value.map(_.dataStorage) should be(List(DataStorageSettings(envelope           = true,
+                                                                    key                = true,
+                                                                    value              = true,
+                                                                    metadata           = false,
+                                                                    headers            = false,
+                                                                    customNamerFactory = None,
         )))
     }
   }
@@ -233,11 +234,12 @@ class GCPStorageGCPStorageSinkConfigDefBuilderTest
     CloudSinkBucketOptions(connectorTaskId, GCPStorageSinkConfigDefBuilder(props)) match {
       case Left(value) => fail(value.toString)
       case Right(value) =>
-        value.map(_.dataStorage) should be(List(DataStorageSettings(envelope = true,
-                                                                    key      = true,
-                                                                    value    = true,
-                                                                    metadata = false,
-                                                                    headers  = false,
+        value.map(_.dataStorage) should be(List(DataStorageSettings(envelope           = true,
+                                                                    key                = true,
+                                                                    value              = true,
+                                                                    metadata           = false,
+                                                                    headers            = false,
+                                                                    customNamerFactory = None,
         )))
     }
   }


### PR DESCRIPTION
Minimal change to provide support for custom file naming

This allows for a custom `FileNamerFactory` to be created (with an optional configuration parameter) 
The `FileNamerFactory` has a single method to create a  `FileNamer` (based on the parameters that the system already has for file namers

A `FileNamer` is an existing interface, and was minimally changed to pass parameters via a case class to limit compatibility issues should additional parameters be supported in the future

TODO

- [ ] Discuss this approach and refine with the maintainers
- [ ] update javadoc to match the modified APIs
- [ ] add tese to the configuration extraction
- [ ] add tests to the custom file buidler

To Explore
It would be good to allow more behaviour to the file naming, for instance 
- to include the start offset, number of records etc
- to ensure hat we never overwrite a file, add a suffix (this would be a change to the behaviour of the `FileNamer` I believe