### PR TITLE
MQTT Source connector more flexible topic-to-target mapping

### DIFF
--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManager.scala
@@ -172,9 +172,12 @@ class MqttManager(
 }
 
 object MqttManager {
-  def replaceSlashes(kcql: Kcql, topic: String): String =
+  def replaceSlashes(kcql: Kcql, topic: String): String = {
+    val sanitizedTopic = topic.replaceFirst("^/", "").replaceAll("/+", "_").replaceAll("/", "_")
     kcql.getTarget match {
-      case "$"   => topic.replaceFirst("^/", "").replaceAll("/+", "_").replaceAll("/", "_")
-      case other => other
+      case "$"                          => sanitizedTopic
+      case other if other.contains("$") => other.replace("$", sanitizedTopic)
+      case other                        => other
     }
+  }
 }

--- a/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManagerTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/io/lenses/streamreactor/connect/mqtt/source/MqttManagerTest.scala
@@ -51,6 +51,28 @@ class MqttManagerTest extends AnyWordSpec with Matchers {
             MqttManager.replaceSlashes(kcql, source) should equal(expected)
         }
       }
+      "replace $ placeholder in a prefixed target with the sanitized MQTT topic" in {
+        val sources = Array(
+          "topic/my-device",
+          "topic/living_room/sensor",
+        )
+
+        val kcqls = Kcql.parseMultiple(
+          "INSERT INTO `prefix_$` SELECT * FROM topic/my-device; INSERT INTO `prefix_$` SELECT * FROM topic/living_room/sensor;",
+        )
+
+        val expectedTargets = Array(
+          "prefix_topic_my-device",
+          "prefix_topic_living_room_sensor",
+        )
+
+        val cases = kcqls.toArray.lazyZip(sources).lazyZip(expectedTargets)
+
+        cases.map {
+          case (kcql: Kcql, source: String, expected: String) =>
+            MqttManager.replaceSlashes(kcql, source) should equal(expected)
+        }
+      }
       "do nothing in other cases and return the actual targeted topic" in {
 
         val sources = Array("xyz", "zyx")


### PR DESCRIPTION

<p><strong>Support partial <code>$</code> placeholder substitution in MQTT target topics</strong></p>
<p>Previously, the <code>$</code> wildcard in KCQL target mappings only worked as a standalone value — <code>getTarget</code> had to return exactly <code>"$"</code> for the MQTT source topic to be used as the target. If a user wrote something like <code>"prefix_$"</code> or <code>"data/$_events"</code>, the <code>$</code> would not be substituted and the literal string (including <code>$</code>) would be used as-is.</p>
<p>This change adds support for <code>$</code> as an embedded placeholder within a larger target string. The sanitized MQTT topic name is now substituted wherever <code>$</code> appears in the target.</p>
<p><strong>Examples:</strong></p>

KCQL Target | MQTT Topic | Before | After
-- | -- | -- | --
$ | /sensor/temp | sensor_temp | sensor_temp
prefix_$ | /sensor/temp | prefix_$ | prefix_sensor_temp
data/$_events | /sensor/temp | data/$_events | data/sensor_temp_events

Resolved the following issue: [#1386 ](https://github.com/lensesio/stream-reactor/issues/1386)