### PR TITLE
fix(cloud-sink): recover from lost master-lock create race (cold-start 409)

### DIFF
--- a/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterface.scala
+++ b/kafka-connect-aws-s3/src/main/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterface.scala
@@ -34,6 +34,7 @@ import io.lenses.streamreactor.connect.cloud.common.storage.FileLoadError
 import io.lenses.streamreactor.connect.cloud.common.storage.GeneralFileLoadError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileMoveError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileNotFoundError
+import io.lenses.streamreactor.connect.cloud.common.storage.NonOverwriteFileExistsError
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfKeysResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfMetadataResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.ListResponse
@@ -401,7 +402,17 @@ class AwsS3StorageInterface(
       new ObjectWithETag[O](objectProtection.wrappedObject, putResponse.eTag())
     }.toEither
       .leftMap {
-        ex =>
+        // NoOverwriteExistingObject lost the create race: the object already exists, so the
+        // ifNoneMatch("*") precondition fails with PreconditionFailed. Recoverable — the caller
+        // re-reads and adopts the lock. Scoped to NoOverwrite: an ObjectWithETag ifMatch
+        // mismatch also surfaces as PreconditionFailed but is the zombie-fencing signal and
+        // MUST stay fatal. Mirrors the recovery clause in createDirectoryIfNotExists.
+        case ex: S3Exception
+            if objectProtection.isInstanceOf[NoOverwriteExistingObject[_]] &&
+              "PreconditionFailed".equals(ex.awsErrorDetails().errorCode()) =>
+          logger.info(s"[{}] Lost no-overwrite create race uploading to s3 {}:{}", connectorTaskId.show, bucket, path)
+          NonOverwriteFileExistsError(ex, path)
+        case ex =>
           logger.error(s"[{}] Failed upload from json object ({}) to s3 {}:{}",
                        connectorTaskId.show,
                        content,

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterfaceTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/storage/AwsS3StorageInterfaceTest.scala
@@ -16,14 +16,22 @@
 package io.lenses.streamreactor.connect.aws.s3.storage
 
 import cats.implicits.none
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
 import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
+import io.lenses.streamreactor.connect.cloud.common.sink.seek.NoOverwriteExistingObject
+import io.lenses.streamreactor.connect.cloud.common.sink.seek.ObjectWithETag
+import io.lenses.streamreactor.connect.cloud.common.storage.FileCreateError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileMoveError
+import io.lenses.streamreactor.connect.cloud.common.storage.NonOverwriteFileExistsError
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails
+import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse
@@ -32,6 +40,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
 
 /**
@@ -176,5 +185,61 @@ class AwsS3StorageInterfaceTest extends AnyFlatSpecLike with Matchers with Eithe
     result.left.value.exception shouldBe a[IllegalStateException]
     Mockito.verify(s3Client, Mockito.never()).copyObject(anyCopyObjectRequest())
     Mockito.verify(s3Client, Mockito.never()).deleteObject(anyDeleteObjectRequest())
+  }
+
+  // ── writeBlobToFile — lost no-overwrite create race ──────────────────────
+
+  private case class TestIndexFile(owner: String, offset: Option[Long])
+  private implicit val testIndexFileEncoder: Encoder[TestIndexFile] = deriveEncoder[TestIndexFile]
+
+  private def anyPutObjectRequest(): PutObjectRequest = ArgumentMatchers.any(classOf[PutObjectRequest])
+  private def anyRequestBody():      RequestBody      = ArgumentMatchers.any(classOf[RequestBody])
+
+  private def s3ExceptionWith(errorCode: String, status: Int): S3Exception =
+    S3Exception.builder()
+      .statusCode(status)
+      .awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build())
+      .build().asInstanceOf[S3Exception]
+
+  "writeBlobToFile" should "return NonOverwriteFileExistsError when NoOverwriteExistingObject loses the race (PreconditionFailed)" in {
+    val s3Client         = newMockS3Client()
+    val storageInterface = new AwsS3StorageInterface(newMockTaskId(), s3Client, batchDelete = false, None)
+
+    Mockito.doThrow(s3ExceptionWith("PreconditionFailed", 412))
+      .when(s3Client).putObject(anyPutObjectRequest(), anyRequestBody())
+
+    val result =
+      storageInterface.writeBlobToFile("bucket", "path", NoOverwriteExistingObject(TestIndexFile("o", Some(1L))))
+
+    result.isLeft shouldBe true
+    result.left.value shouldBe a[NonOverwriteFileExistsError]
+  }
+
+  it should "return FileCreateError (not NonOverwriteFileExistsError) when ObjectWithETag and PreconditionFailed — fencing must stay fatal" in {
+    val s3Client         = newMockS3Client()
+    val storageInterface = new AwsS3StorageInterface(newMockTaskId(), s3Client, batchDelete = false, None)
+
+    Mockito.doThrow(s3ExceptionWith("PreconditionFailed", 412))
+      .when(s3Client).putObject(anyPutObjectRequest(), anyRequestBody())
+
+    val result =
+      storageInterface.writeBlobToFile("bucket", "path", ObjectWithETag(TestIndexFile("o", Some(1L)), "etag"))
+
+    result.isLeft shouldBe true
+    result.left.value shouldBe a[FileCreateError]
+  }
+
+  it should "return FileCreateError when NoOverwriteExistingObject fails with a non-precondition error" in {
+    val s3Client         = newMockS3Client()
+    val storageInterface = new AwsS3StorageInterface(newMockTaskId(), s3Client, batchDelete = false, None)
+
+    Mockito.doThrow(s3ExceptionWith("InternalError", 500))
+      .when(s3Client).putObject(anyPutObjectRequest(), anyRequestBody())
+
+    val result =
+      storageInterface.writeBlobToFile("bucket", "path", NoOverwriteExistingObject(TestIndexFile("o", Some(1L))))
+
+    result.isLeft shouldBe true
+    result.left.value shouldBe a[FileCreateError]
   }
 }

--- a/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterface.scala
+++ b/kafka-connect-azure-datalake/src/main/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterface.scala
@@ -452,6 +452,21 @@ class DatalakeStorageInterface(connectorTaskId: ConnectorTaskId, client: DataLak
       }.toEither.leftMap(FileDeleteError(_, file))
     } yield ()
 
+  /**
+   * True when a failed rename represents a NoOverwriteExistingObject create losing the race —
+   * i.e. the destination already exists. ADLS surfaces this as 409 PathAlreadyExists or 412.
+   * Scoped to NoOverwrite: an ObjectWithETag 412 is an eTag mismatch (fencing) and must NOT
+   * be reclassified as recoverable.
+   */
+  private def isLostNoOverwriteRace[O](
+    objectProtection: ObjectProtection[O],
+    dse:              DataLakeStorageException,
+  ): Boolean =
+    objectProtection match {
+      case NoOverwriteExistingObject(_) => dse.getStatusCode == 409 || dse.getStatusCode == 412
+      case _                            => false
+    }
+
   override def writeBlobToFile[O](
     bucket:           String,
     path:             String,
@@ -481,9 +496,10 @@ class DatalakeStorageInterface(connectorTaskId: ConnectorTaskId, client: DataLak
     val destinationConditions: DataLakeRequestConditions = objectProtection match {
       case NoOverwriteExistingObject(_) =>
         // Atomic arbitration: exactly one of N concurrent renames to the same destination
-        // wins; the rest get 412 Precondition Failed. The downstream Left(FileCreateError)
-        // contract is unchanged — the numeric 412 replaces the historical 409 from
-        // createFile(false), but all callers consume only the wrapper class.
+        // wins; the losers fail with EITHER 409 PathAlreadyExists (observed in prod) OR 412
+        // Precondition Failed. Both are mapped to the recoverable NonOverwriteFileExistsError
+        // (see isLostNoOverwriteRace + tryWriteViaRenameWithDirectoryRecovery), so the loser
+        // re-reads and adopts the lock instead of failing the task.
         new DataLakeRequestConditions().setIfNoneMatch("*")
       case ObjectWithETag(_, eTag) =>
         // eTag here is the eTag of the CURRENT DESTINATION (sourced from topicPartitionToETags /
@@ -592,11 +608,22 @@ class DatalakeStorageInterface(connectorTaskId: ConnectorTaskId, client: DataLak
             case None => Left(FileCreateError(dse, content))
           }
 
+        case Left(dse: DataLakeStorageException) if isLostNoOverwriteRace(objectProtection, dse) =>
+          // NoOverwriteExistingObject lost the create race: the destination already exists.
+          // ADLS Gen2 HNS surfaces this as EITHER 409 PathAlreadyExists (observed in prod on the
+          // rename) OR 412 Precondition Failed (setIfNoneMatch("*") arbitration). Both mean
+          // "another task won". Recoverable: IndexManagerV2.open re-reads and adopts the lock.
+          // This is scoped to NoOverwrite only — an ObjectWithETag 412 (eTag mismatch) is the
+          // zombie-fencing signal and falls through to the fatal FileCreateError arm below.
+          logger.info(
+            s"[${connectorTaskId.show}] Lost no-overwrite create race renaming $tmpPath -> $bucket:$path " +
+              s"(status ${dse.getStatusCode}); surfacing recoverable NonOverwriteFileExistsError",
+          )
+          Left(NonOverwriteFileExistsError(dse, path))
+
         case Left(dse: DataLakeStorageException) if dse.getStatusCode == 412 =>
-          // 412 Precondition Failed: destination-slot condition not met.
-          // For NoOverwriteExistingObject: destination already exists.
-          // For ObjectWithETag: eTag mismatch (concurrent write by another task).
-          // Both surface as Left(FileCreateError) — callers only inspect the wrapper class.
+          // 412 Precondition Failed on an ObjectWithETag write: eTag mismatch (concurrent write
+          // by another task). This is the zombie-fencing mechanism and MUST stay fatal.
           logger.warn(
             s"[${connectorTaskId.show}] Precondition failed (412) renaming $tmpPath -> $bucket:$path",
           )

--- a/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
+++ b/kafka-connect-azure-datalake/src/test/scala/io/lenses/streamreactor/connect/datalake/storage/DatalakeStorageInterfaceTest.scala
@@ -57,6 +57,7 @@ import io.lenses.streamreactor.connect.cloud.common.storage.FileMoveError
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfKeysResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfMetadataResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.NonExistingFileError
+import io.lenses.streamreactor.connect.cloud.common.storage.NonOverwriteFileExistsError
 import io.lenses.streamreactor.connect.cloud.common.storage.PathError
 import io.lenses.streamreactor.connect.cloud.common.storage.UploadFailedError
 import io.lenses.streamreactor.connect.cloud.common.storage.ZeroByteFileError
@@ -1214,12 +1215,13 @@ class DatalakeStorageInterfaceTest
     destConditionsCaptor.getValue.getIfNoneMatch should be("*")
   }
 
-  "writeBlobToFile" should "return FileCreateError when NoOverwriteExistingObject and destination exists (412 from rename)" in {
-    val bucket   = "test-bucket"
-    val path     = "test-path/index.lock"
-    val tmpPath  = s"$path.tmp.${connectorTaskId.lockUuid}"
-    val testData = TestIndexFile("owner-123", Some(100L))
-
+  // Sets up the .tmp create + flush mocks and makes the rename throw the supplied exception.
+  private def setupAtomicWriteRenameThrows(
+    bucket:    String,
+    path:      String,
+    exception: Throwable,
+  ): Unit = {
+    val tmpPath   = s"$path.tmp.${connectorTaskId.lockUuid}"
     val fsClient  = mock[DataLakeFileSystemClient]
     val tmpClient = mock[DataLakeFileClient]
     val flushResp = mock[Response[PathInfo]]
@@ -1241,13 +1243,71 @@ class DatalakeStorageInterfaceTest
         any[Context],
       ),
     ).thenReturn(flushResp)
+    when(tmpClient.renameWithResponse(eqTo(bucket), eqTo(path), any, any, any, any)).thenThrow(exception)
+  }
+
+  "writeBlobToFile" should "return NonOverwriteFileExistsError when NoOverwriteExistingObject and destination exists (412 from rename)" in {
+    val bucket   = "test-bucket"
+    val path     = "test-path/index.lock"
+    val testData = TestIndexFile("owner-123", Some(100L))
 
     // Rename fails with 412 (destination already exists — NoOverwrite condition not met)
-    when(tmpClient.renameWithResponse(eqTo(bucket), eqTo(path), any, any, any, any)).thenThrow(
-      new DataLakeStorageException("ConditionNotMet", mockHttpResponse(412), null),
+    setupAtomicWriteRenameThrows(bucket,
+                                 path,
+                                 new DataLakeStorageException("ConditionNotMet", mockHttpResponse(412), null),
     )
 
     val result = storageInterface.writeBlobToFile(bucket, path, NoOverwriteExistingObject(testData))
+
+    result.isLeft should be(true)
+    result.left.value should be(a[NonOverwriteFileExistsError])
+  }
+
+  "writeBlobToFile" should "return NonOverwriteFileExistsError when NoOverwriteExistingObject and destination exists (409 PathAlreadyExists from rename)" in {
+    val bucket   = "test-bucket"
+    val path     = "test-path/index.lock"
+    val testData = TestIndexFile("owner-123", Some(100L))
+
+    // ADLS Gen2 HNS surfaces the lost no-overwrite create race as 409 PathAlreadyExists on rename.
+    setupAtomicWriteRenameThrows(bucket,
+                                 path,
+                                 new DataLakeStorageException("PathAlreadyExists", mockHttpResponse(409), null),
+    )
+
+    val result = storageInterface.writeBlobToFile(bucket, path, NoOverwriteExistingObject(testData))
+
+    result.isLeft should be(true)
+    result.left.value should be(a[NonOverwriteFileExistsError])
+  }
+
+  "writeBlobToFile" should "return FileCreateError (not NonOverwriteFileExistsError) when ObjectWithETag and rename 412s — fencing must stay fatal" in {
+    val bucket   = "test-bucket"
+    val path     = "test-path/index.lock"
+    val testData = TestIndexFile("owner-123", Some(100L))
+
+    // 412 on an eTag-conditional write is a concurrent-write fence, NOT a lost create race.
+    setupAtomicWriteRenameThrows(bucket,
+                                 path,
+                                 new DataLakeStorageException("ConditionNotMet", mockHttpResponse(412), null),
+    )
+
+    val result = storageInterface.writeBlobToFile(bucket, path, ObjectWithETag(testData, "existing-etag"))
+
+    result.isLeft should be(true)
+    result.left.value should be(a[FileCreateError])
+  }
+
+  "writeBlobToFile" should "return FileCreateError (not NonOverwriteFileExistsError) when ObjectWithETag and rename 409s — 409 reclassification is NoOverwrite-only" in {
+    val bucket   = "test-bucket"
+    val path     = "test-path/index.lock"
+    val testData = TestIndexFile("owner-123", Some(100L))
+
+    setupAtomicWriteRenameThrows(bucket,
+                                 path,
+                                 new DataLakeStorageException("PathAlreadyExists", mockHttpResponse(409), null),
+    )
+
+    val result = storageInterface.writeBlobToFile(bucket, path, ObjectWithETag(testData, "existing-etag"))
 
     result.isLeft should be(true)
     result.left.value should be(a[FileCreateError])

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/seek/IndexManagerV2.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/sink/seek/IndexManagerV2.scala
@@ -34,6 +34,7 @@ import io.lenses.streamreactor.connect.cloud.common.storage.EmptyFileError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileLoadError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileMetadata
 import io.lenses.streamreactor.connect.cloud.common.storage.FileNotFoundError
+import io.lenses.streamreactor.connect.cloud.common.storage.NonOverwriteFileExistsError
 import io.lenses.streamreactor.connect.cloud.common.storage.StorageInterface
 import io.lenses.streamreactor.connect.cloud.common.storage.UploadError
 
@@ -300,68 +301,121 @@ class IndexManagerV2(
     for {
       bucketAndPrefix <- bucketAndPrefixFn(topicPartition)
       _               <- migrateOldPathIfExists(bucketAndPrefix, maybeOldPath, path, topicPartition)
-      offset <- tryOpen(bucketAndPrefix.bucket, path) match {
-
-        case Left(FileNotFoundError(_, _)) =>
-          createNewIndexFileNoOverwrite(topicPartition, path, bucketAndPrefix)
-            .map(updateDataReturnOffset(topicPartition, _))
-
-        case Left(EmptyFileError(_, eTag)) =>
-          // The master lock exists as a 0-byte poison blob — residue of Bug B's non-atomic write.
-          // A length-0 blob cannot carry committedOffset or PendingState by construction
-          // (the serialiser produces at minimum ~40 bytes for any non-null IndexFile).
-          // Take ownership via setIfMatch(eTag) instead of setIfNoneMatch("*") — the file
-          // exists, so a NoOverwrite write would always 412.
-          // NOTE: pendingOperationsProcessors is NOT invoked here — the 0-byte file proves
-          // no PendingState was ever durably recorded; the recovery write sets pendingState=None.
-          for {
-            tpo <- oldIndexManager.seekOffsetsForTopicPartition(topicPartition)
-            idx  = IndexFile(lockOwner, tpo.map(_.offset), Option.empty)
-            blobWrite <- storageInterface.writeBlobToFile(bucketAndPrefix.bucket, path, ObjectWithETag(idx, eTag))
-              .leftMap { err: UploadError =>
-                new FatalCloudSinkError(err.message(), err.toExceptionOption, topicPartition)
-              }
-          } yield updateDataReturnOffset(topicPartition, blobWrite)
-
-        case Left(fileLoadError: FileLoadError) =>
-          new FatalCloudSinkError(fileLoadError.message(), fileLoadError.toExceptionOption, topicPartition).asLeft[
-            Option[Offset],
-          ]
-
-        case Right(objectWithetag @ ObjectWithETag(
-              IndexFile(_, committedOffset, Some(PendingState(pendingOffset, pendingOperations))),
-              _,
-            )) =>
-          topicPartitionToETags.put(topicPartition, objectWithetag.eTag)
-          pendingOperationsProcessors.processPendingOperations(
-            topicPartition,
-            committedOffset,
-            PendingState(pendingOffset, pendingOperations),
-            update,
-          ).map { resolvedOffset =>
-            // processPendingOperations calls update() which already maintains topicPartitionToETags
-            // with the correct eTag. We must NOT overwrite it with the stale original eTag.
-            // Only ensure seekedOffsets is updated for cases where update() was not called
-            // (e.g. when the recovery path cleared a stale PendingState on the last operation).
-            resolvedOffset.foreach(o => seekedOffsets.put(topicPartition, o))
-            resolvedOffset
-          }.leftMap { err =>
-            // On failure, the eTag we seeded above may now be stale: an intermediate
-            // phase of processPendingOperations may have advanced the index file in
-            // storage before the final fnIndexUpdate failed. Drop the cached eTag so
-            // the next call re-reads the file and we never issue a conditional write
-            // with the wrong If-Match. Mirrors the gcRemove-on-failure pattern used
-            // when loading granular locks.
-            val _ = topicPartitionToETags.remove(topicPartition)
-            err
-          }
-
-        case Right(objectWithetag @ ObjectWithETag(IndexFile(_, _, _), _)) =>
-          updateDataReturnOffset(topicPartition, objectWithetag).asRight[SinkError]
-      }
+      offset <- decideOpen(
+        topicPartition,
+        path,
+        bucketAndPrefix,
+        tryOpen(bucketAndPrefix.bucket, path),
+        MaxOpenCreateRaceAttempts,
+      )
     } yield offset
 
   }
+
+  /**
+   * Decides how to open a master lock given the result of reading it, and is re-entrant so a
+   * lost NoOverwrite create race can re-read the now-existing lock and route it through the
+   * SAME arms (crucially, a re-read lock carrying a PendingState flows through
+   * `processPendingOperations`, not a naive eTag adoption — that is what makes recovery
+   * correct, see the architecture note on the reverted create-race adoption fix).
+   *
+   * @param tryOpenResult The result of `tryOpen` for this lock path.
+   * @param attemptsLeft  Bounded re-read budget for the lost-create-race cycle.
+   */
+  private def decideOpen(
+    topicPartition:  TopicPartition,
+    path:            String,
+    bucketAndPrefix: CloudLocation,
+    tryOpenResult:   Either[FileLoadError, ObjectWithETag[IndexFile]],
+    attemptsLeft:    Int,
+  ): Either[SinkError, Option[Offset]] =
+    tryOpenResult match {
+
+      case Left(FileNotFoundError(_, _)) =>
+        createNewIndexFileNoOverwrite(topicPartition, path, bucketAndPrefix) match {
+          case Right(written) =>
+            updateDataReturnOffset(topicPartition, written).asRight[SinkError]
+
+          case Left(_: LostCreateRaceError) if attemptsLeft > 1 =>
+            // Another task won the create. The lock now exists — re-read and re-decide through
+            // the same arms so the winner's offset (and any PendingState) is adopted/recovered.
+            logger.info(
+              s"[${connectorTaskId.show}] Lost master-lock create race for $topicPartition at $path; " +
+                s"re-reading existing lock (attempts left: ${attemptsLeft - 1})",
+            )
+            decideOpen(
+              topicPartition,
+              path,
+              bucketAndPrefix,
+              tryOpen(bucketAndPrefix.bucket, path),
+              attemptsLeft - 1,
+            )
+
+          case Left(_: LostCreateRaceError) =>
+            // Bounded retries exhausted: the lock oscillated absent/present. Fail fatally so
+            // Connect restarts the task and re-seeks from the durable lock — no worse than the
+            // pre-fix behaviour, but only after exhausting the bounded re-reads.
+            FatalCloudSinkError(
+              s"Exhausted master-lock create-race retries for $topicPartition at $path",
+              topicPartition,
+            ).asLeft[Option[Offset]]
+
+          case Left(other) => other.asLeft[Option[Offset]]
+        }
+
+      case Left(EmptyFileError(_, eTag)) =>
+        // The master lock exists as a 0-byte poison blob — residue of Bug B's non-atomic write.
+        // A length-0 blob cannot carry committedOffset or PendingState by construction
+        // (the serialiser produces at minimum ~40 bytes for any non-null IndexFile).
+        // Take ownership via setIfMatch(eTag) instead of setIfNoneMatch("*") — the file
+        // exists, so a NoOverwrite write would always 412.
+        // NOTE: pendingOperationsProcessors is NOT invoked here — the 0-byte file proves
+        // no PendingState was ever durably recorded; the recovery write sets pendingState=None.
+        for {
+          tpo <- oldIndexManager.seekOffsetsForTopicPartition(topicPartition)
+          idx  = IndexFile(lockOwner, tpo.map(_.offset), Option.empty)
+          blobWrite <- storageInterface.writeBlobToFile(bucketAndPrefix.bucket, path, ObjectWithETag(idx, eTag))
+            .leftMap { err: UploadError =>
+              new FatalCloudSinkError(err.message(), err.toExceptionOption, topicPartition)
+            }
+        } yield updateDataReturnOffset(topicPartition, blobWrite)
+
+      case Left(fileLoadError: FileLoadError) =>
+        new FatalCloudSinkError(fileLoadError.message(), fileLoadError.toExceptionOption, topicPartition).asLeft[
+          Option[Offset],
+        ]
+
+      case Right(objectWithetag @ ObjectWithETag(
+            IndexFile(_, committedOffset, Some(PendingState(pendingOffset, pendingOperations))),
+            _,
+          )) =>
+        topicPartitionToETags.put(topicPartition, objectWithetag.eTag)
+        pendingOperationsProcessors.processPendingOperations(
+          topicPartition,
+          committedOffset,
+          PendingState(pendingOffset, pendingOperations),
+          update,
+        ).map { resolvedOffset =>
+          // processPendingOperations calls update() which already maintains topicPartitionToETags
+          // with the correct eTag. We must NOT overwrite it with the stale original eTag.
+          // Only ensure seekedOffsets is updated for cases where update() was not called
+          // (e.g. when the recovery path cleared a stale PendingState on the last operation).
+          resolvedOffset.foreach(o => seekedOffsets.put(topicPartition, o))
+          resolvedOffset
+        }.leftMap { err =>
+          // On failure, the eTag we seeded above may now be stale: an intermediate
+          // phase of processPendingOperations may have advanced the index file in
+          // storage before the final fnIndexUpdate failed. Drop the cached eTag so
+          // the next call re-reads the file and we never issue a conditional write
+          // with the wrong If-Match. Mirrors the gcRemove-on-failure pattern used
+          // when loading granular locks.
+          val _ = topicPartitionToETags.remove(topicPartition)
+          err
+        }
+
+      case Right(objectWithetag @ ObjectWithETag(IndexFile(_, _, _), _)) =>
+        updateDataReturnOffset(topicPartition, objectWithetag).asRight[SinkError]
+    }
 
   private def migrateOldPathIfExists(
     bucketAndPrefix: CloudLocation,
@@ -465,8 +519,13 @@ class IndexManagerV2(
       )
 
       blobWrite <- storageInterface.writeBlobToFile(bucketAndPrefix.bucket, path, NoOverwriteExistingObject(idx))
-        .leftMap { err: UploadError =>
-          new FatalCloudSinkError(err.message(), err.toExceptionOption, topicPartition)
+        .leftMap {
+          // Lost the create race (another task created the lock first). Surface a recoverable
+          // signal so `decideOpen` re-reads and adopts the winner's lock instead of failing.
+          case _: NonOverwriteFileExistsError => LostCreateRaceError(topicPartition): SinkError
+          // Any other write failure (permissions, network, disk) is genuinely fatal.
+          case err: UploadError =>
+            new FatalCloudSinkError(err.message(), err.toExceptionOption, topicPartition): SinkError
         }
     } yield {
       blobWrite
@@ -1425,6 +1484,27 @@ object IndexManagerV2 {
   private[seek] val TmpOrphanPattern = """^(.*)\.lock\.tmp\.[0-9a-fA-F-]+$""".r
 
   val MaxGcRetries: Int = 3
+
+  /**
+   * Bounded re-read attempts when a master-lock NoOverwrite create loses the race. One re-read
+   * normally suffices — cloud storage is read-after-write consistent for the destination — so
+   * the cap only guards against a pathological absent/present flicker before surfacing a fatal
+   * error.
+   */
+  val MaxOpenCreateRaceAttempts: Int = 3
+
+  /**
+   * Internal, recoverable signal: a master-lock NoOverwrite create lost the race because the
+   * lock already exists. It NEVER escapes `IndexManagerV2.open` — `decideOpen` either resolves
+   * it with a bounded re-read (adopting the winner's lock, including any PendingState recovery)
+   * or converts it to a `FatalCloudSinkError` on exhaustion.
+   */
+  private[seek] case class LostCreateRaceError(topicPartition: TopicPartition) extends SinkError {
+    override def exception():       Option[Throwable]   = Option.empty
+    override def message():         String              = s"lost master-lock create race for $topicPartition"
+    override def rollBack():        Boolean             = false
+    override def topicPartitions(): Set[TopicPartition] = Set(topicPartition)
+  }
 
   private[seek] case class SweepMarker(lastRunEpochMillis: Long, nextRunEpochMillis: Long)
 

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/storage/UploadError.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/storage/UploadError.scala
@@ -56,6 +56,23 @@ case class FileCreateError(exception: Throwable, data: String) extends UploadErr
   override def toExceptionOption: Option[Throwable] = exception.some
 }
 
+/**
+ * Returned ONLY when a `NoOverwriteExistingObject` create lost a concurrent create race —
+ * i.e. the destination object already exists (Azure 409 PathAlreadyExists / 412, S3
+ * PreconditionFailed, GCS 412 generation mismatch).
+ *
+ * Unlike `FileCreateError` this is a *recoverable* signal: the caller (IndexManagerV2.open)
+ * re-reads the now-existing lock and adopts/recovers it (routing any PendingState through the
+ * crash-recovery path) rather than failing the task. It is NEVER emitted for an
+ * `ObjectWithETag` write — an eTag mismatch there is the zombie-fencing mechanism and must
+ * remain a fatal `FileCreateError`.
+ */
+case class NonOverwriteFileExistsError(exception: Throwable, fileName: String) extends UploadError {
+  override def message() = s"file already exists, lost no-overwrite create race ($fileName) ${exception.getMessage}"
+
+  override def toExceptionOption: Option[Throwable] = exception.some
+}
+
 case class FileDeleteError(exception: Throwable, fileName: String) extends UploadError {
   override def message() = s"error deleting file ($fileName) ${exception.getMessage}"
 

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/seek/IndexManagerV2Test.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/seek/IndexManagerV2Test.scala
@@ -31,7 +31,9 @@ import io.lenses.streamreactor.connect.cloud.common.sink.SinkError
 import io.lenses.streamreactor.connect.cloud.common.sink.seek.deprecated.IndexManagerV1
 import io.lenses.streamreactor.connect.cloud.common.model.UploadableFile
 import io.lenses.streamreactor.connect.cloud.common.storage.EmptyFileError
+import io.lenses.streamreactor.connect.cloud.common.storage.FileLoadError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileNotFoundError
+import io.lenses.streamreactor.connect.cloud.common.storage.NonOverwriteFileExistsError
 import io.lenses.streamreactor.connect.cloud.common.storage.GeneralFileLoadError
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfMetadataResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.NonExistingFileError
@@ -125,6 +127,130 @@ class IndexManagerV2Test
     val result: Either[SinkError, Map[TopicPartition, Option[Offset]]] = runOpen(topicPartition, bucketAndPrefix, path)
 
     result shouldBe Right(Map(topicPartition -> None))
+  }
+
+  test("open should adopt the existing lock when the master-lock create loses the race (clean lock)") {
+    val topicPartition  = Topic("topic1").withPartition(0)
+    val bucketAndPrefix = CloudLocation("bucket", "prefix".some)
+    val path            = ".indexes/.locks/topic1/0.lock"
+
+    when(oldIndexManager.seekOffsetsForTopicPartition(topicPartition)).thenReturn(Option.empty.asRight)
+    when(bucketAndPrefixFn(topicPartition)).thenReturn(Right(bucketAndPrefix))
+    when(storageInterface.pathExists(anyString(), anyString())).thenReturn(Right(false))
+    when(storageInterface.listKeysRecursive(anyString(), any[Option[String]])).thenReturn(Right(None))
+
+    // First read: lock absent → create. Second read (after losing the race): the winner's lock.
+    val absent: Either[FileLoadError, ObjectWithETag[IndexFile]] =
+      Left(FileNotFoundError(new Exception("Not found"), path))
+    val winnerLock: Either[FileLoadError, ObjectWithETag[IndexFile]] =
+      Right(ObjectWithETag(IndexFile("winner", Some(Offset(100)), None), "winner-etag"))
+    when(storageInterface.getBlobAsObject[IndexFile](anyString(), anyString())(ArgumentMatchers.eq(indexFileDecoder)))
+      .thenReturn(absent, winnerLock)
+
+    // The NoOverwrite create loses the race.
+    when(
+      storageInterface.writeBlobToFile[IndexFile](anyString(), anyString(), any[ObjectWithETag[IndexFile]])(
+        ArgumentMatchers.eq(indexFileEncoder),
+      ),
+    ).thenReturn(Left(NonOverwriteFileExistsError(new Exception("exists"), path)))
+
+    val result = indexManagerV2.open(Set(topicPartition))
+
+    result shouldBe Right(Map(topicPartition -> Some(Offset(100))))
+    // The adopted eTag drives subsequent conditional commits.
+    indexManagerV2.getSeekedOffsetForTopicPartition(topicPartition) shouldBe Some(Offset(100))
+    verify(storageInterface, times(2))
+      .getBlobAsObject[IndexFile](anyString(), anyString())(ArgumentMatchers.eq(indexFileDecoder))
+    verify(storageInterface, times(1))
+      .writeBlobToFile[IndexFile](anyString(), anyString(), any[ObjectWithETag[IndexFile]])(
+        ArgumentMatchers.eq(indexFileEncoder),
+      )
+  }
+
+  test("open should resolve PendingState via processPendingOperations when the create loses the race") {
+    val topicPartition  = Topic("topic1").withPartition(0)
+    val bucketAndPrefix = CloudLocation("bucket", "prefix".some)
+    val path            = ".indexes/.locks/topic1/0.lock"
+
+    val pendingOps = NonEmptyList.of[FileOperation](
+      CopyOperation("bucket", ".temp-upload/uuid/file.avro", "topic1/0/000000000060.avro", "copy-etag"),
+      DeleteOperation("bucket", ".temp-upload/uuid/file.avro", "copy-etag"),
+    )
+    val pendingState = PendingState(pendingOffset = Offset(60), pendingOperations = pendingOps)
+
+    when(oldIndexManager.seekOffsetsForTopicPartition(topicPartition)).thenReturn(Option.empty.asRight)
+    when(bucketAndPrefixFn(topicPartition)).thenReturn(Right(bucketAndPrefix))
+    when(storageInterface.pathExists(anyString(), anyString())).thenReturn(Right(false))
+    when(storageInterface.listKeysRecursive(anyString(), any[Option[String]])).thenReturn(Right(None))
+
+    // First read: absent → create. Re-read after losing the race: winner's lock carrying a PendingState.
+    val absent: Either[FileLoadError, ObjectWithETag[IndexFile]] =
+      Left(FileNotFoundError(new Exception("Not found"), path))
+    val winnerPendingLock: Either[FileLoadError, ObjectWithETag[IndexFile]] =
+      Right(ObjectWithETag(IndexFile("winner", Some(Offset(50)), Some(pendingState)), "winner-etag"))
+    when(storageInterface.getBlobAsObject[IndexFile](anyString(), anyString())(ArgumentMatchers.eq(indexFileDecoder)))
+      .thenReturn(absent, winnerPendingLock)
+
+    when(
+      storageInterface.writeBlobToFile[IndexFile](anyString(), anyString(), any[ObjectWithETag[IndexFile]])(
+        ArgumentMatchers.eq(indexFileEncoder),
+      ),
+    ).thenReturn(Left(NonOverwriteFileExistsError(new Exception("exists"), path)))
+
+    // The re-read MUST flow through processPendingOperations (not a naive eTag adoption).
+    type FnIndexUpdate = (TopicPartition, Option[Offset], Option[PendingState]) => Either[SinkError, Option[Offset]]
+    when(
+      pendingOperationsProcessors.processPendingOperations(
+        any[TopicPartition],
+        any[Option[Offset]],
+        any[PendingState],
+        any[FnIndexUpdate],
+        any[Boolean],
+        any[Option[String]],
+        any[Option[java.io.File]],
+      ),
+    ).thenReturn(Right(Some(Offset(60))))
+
+    val result = indexManagerV2.open(Set(topicPartition))
+
+    result shouldBe Right(Map(topicPartition -> Some(Offset(60))))
+    verify(pendingOperationsProcessors).processPendingOperations(
+      eqTo(topicPartition),
+      eqTo(Some(Offset(50))),
+      eqTo(pendingState),
+      any[FnIndexUpdate],
+      any[Boolean],
+      any[Option[String]],
+      any[Option[java.io.File]],
+    )
+  }
+
+  test("open should fail fatally after exhausting bounded create-race retries") {
+    val topicPartition  = Topic("topic1").withPartition(0)
+    val bucketAndPrefix = CloudLocation("bucket", "prefix".some)
+    val path            = ".indexes/.locks/topic1/0.lock"
+
+    when(oldIndexManager.seekOffsetsForTopicPartition(topicPartition)).thenReturn(Option.empty.asRight)
+    when(bucketAndPrefixFn(topicPartition)).thenReturn(Right(bucketAndPrefix))
+    when(storageInterface.pathExists(anyString(), anyString())).thenReturn(Right(false))
+    when(storageInterface.listKeysRecursive(anyString(), any[Option[String]])).thenReturn(Right(None))
+
+    // The lock oscillates absent/present: every read says absent, every create loses the race.
+    when(storageInterface.getBlobAsObject[IndexFile](anyString(), anyString())(ArgumentMatchers.eq(indexFileDecoder)))
+      .thenReturn(Left(FileNotFoundError(new Exception("Not found"), path)))
+    when(
+      storageInterface.writeBlobToFile[IndexFile](anyString(), anyString(), any[ObjectWithETag[IndexFile]])(
+        ArgumentMatchers.eq(indexFileEncoder),
+      ),
+    ).thenReturn(Left(NonOverwriteFileExistsError(new Exception("exists"), path)))
+
+    val result = indexManagerV2.open(Set(topicPartition))
+
+    result.isLeft shouldBe true
+    result.left.value shouldBe a[FatalCloudSinkError]
+    // Exactly MaxOpenCreateRaceAttempts (3) reads before giving up.
+    verify(storageInterface, times(3))
+      .getBlobAsObject[IndexFile](anyString(), anyString())(ArgumentMatchers.eq(indexFileDecoder))
   }
 
   private def runOpen(topicPartition: TopicPartition, bucketAndPrefix: CloudLocation, path: String) = {
@@ -2437,11 +2563,11 @@ class IndexManagerV2Test
     val si              = mock[StorageInterface[_]]
     setupSweepMocks(si, tp, bucketAndPrefix)
 
-    val pk        = "name=report.lock.tmp.archive"
-    val oldTime   = Instant.now().minusSeconds(7200)
-    val realLock  = s"$indexesDirectoryName/${connectorTaskId.name}/.locks/${tp.topic}/${tp.partition}/$pk.lock"
-    val realMeta  = TestFileMetadata(realLock, oldTime)
-    val listResp  = ListOfMetadataResponse("bucket", Some("prefix"), Seq(realMeta), realMeta)
+    val pk       = "name=report.lock.tmp.archive"
+    val oldTime  = Instant.now().minusSeconds(7200)
+    val realLock = s"$indexesDirectoryName/${connectorTaskId.name}/.locks/${tp.topic}/${tp.partition}/$pk.lock"
+    val realMeta = TestFileMetadata(realLock, oldTime)
+    val listResp = ListOfMetadataResponse("bucket", Some("prefix"), Seq(realMeta), realMeta)
 
     org.mockito.Mockito.doReturn(Right(Some(listResp))).when(si).listFileMetaRecursive(anyString(), any[Option[String]])
     // Real lock content with committedOffset >= masterOffset (100), so the normal

--- a/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageStorageInterface.scala
+++ b/kafka-connect-gcp-storage/src/main/scala/io/lenses/streamreactor/connect/gcp/storage/storage/GCPStorageStorageInterface.scala
@@ -45,6 +45,7 @@ import io.lenses.streamreactor.connect.cloud.common.storage.FileLoadError
 import io.lenses.streamreactor.connect.cloud.common.storage.GeneralFileLoadError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileMoveError
 import io.lenses.streamreactor.connect.cloud.common.storage.FileNotFoundError
+import io.lenses.streamreactor.connect.cloud.common.storage.NonOverwriteFileExistsError
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfKeysResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfMetadataResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.PathError
@@ -217,16 +218,29 @@ class GCPStorageStorageInterface(
         path,
       )
       new ObjectWithETag[O](objectProtection.wrappedObject, String.valueOf(created.getGeneration))
-    }.toEither.leftMap { ex: Throwable =>
-      logger.error(
-        s"[{}] Failed upload from data string ({}) to Storage {}:{}",
-        connectorTaskId.show,
-        objectProtection.wrappedObject,
-        bucket,
-        path,
-        ex,
-      )
-      FileCreateError(ex, content)
+    }.toEither.leftMap {
+      // NoOverwriteExistingObject lost the create race: the object already exists, so the
+      // generationMatch(0L) precondition fails with 412. Recoverable — the caller re-reads and
+      // adopts the lock. Scoped to NoOverwrite: an ObjectWithETag generationMatch mismatch also
+      // surfaces as 412 but is the zombie-fencing signal and MUST stay fatal.
+      case se: StorageException if objectProtection.isInstanceOf[NoOverwriteExistingObject[_]] && se.getCode == 412 =>
+        logger.info(
+          s"[{}] Lost no-overwrite create race uploading to Storage {}:{}",
+          connectorTaskId.show,
+          bucket,
+          path,
+        )
+        NonOverwriteFileExistsError(se, path)
+      case ex: Throwable =>
+        logger.error(
+          s"[{}] Failed upload from data string ({}) to Storage {}:{}",
+          connectorTaskId.show,
+          objectProtection.wrappedObject,
+          bucket,
+          path,
+          ex,
+        )
+        FileCreateError(ex, content)
     }
   }
 

--- a/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/GCPStorageStorageInterfaceTest.scala
+++ b/kafka-connect-gcp-storage/src/test/scala/io/lenses/streamreactor/connect/gcp/storage/GCPStorageStorageInterfaceTest.scala
@@ -38,10 +38,14 @@ import com.google.cloud.storage.BlobId
 import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.Storage.BlobListOption
+import com.google.cloud.storage.Storage.BlobTargetOption
+import com.google.cloud.storage.StorageException
 import io.lenses.streamreactor.connect.cloud.common.config.ConnectorTaskId
 import io.lenses.streamreactor.connect.cloud.common.config.ObjectMetadata
 import io.lenses.streamreactor.connect.cloud.common.model.UploadableFile
 import io.lenses.streamreactor.connect.cloud.common.model.UploadableString
+import io.lenses.streamreactor.connect.cloud.common.sink.seek.NoOverwriteExistingObject
+import io.lenses.streamreactor.connect.cloud.common.sink.seek.ObjectWithETag
 import io.lenses.streamreactor.connect.cloud.common.storage._
 import io.lenses.streamreactor.connect.gcp.storage.storage.GCPStorageFileMetadata
 import io.lenses.streamreactor.connect.gcp.storage.storage.GCPStorageStorageInterface
@@ -740,6 +744,45 @@ class GCPStorageStorageInterfaceTest
     val source = File.createTempFile("a-file", "")
     Files.writeString(source.toPath, "real file content", StandardOpenOption.WRITE)
     source
+  }
+
+  // ── writeBlobToFile — lost no-overwrite create race ──────────────────────
+
+  private case class TestIndexFile(owner: String, offset: Option[Long])
+  private implicit val testIndexFileEncoder: io.circe.Encoder[TestIndexFile] =
+    io.circe.generic.semiauto.deriveEncoder[TestIndexFile]
+
+  "writeBlobToFile" should "return NonOverwriteFileExistsError when NoOverwriteExistingObject loses the race (412)" in {
+    when(client.create(any[BlobInfo], any[Array[Byte]], any[BlobTargetOption]))
+      .thenThrow(new StorageException(412, "Precondition Failed"))
+
+    val result =
+      storageInterface.writeBlobToFile("bucket", "path", NoOverwriteExistingObject(TestIndexFile("o", Some(1L))))
+
+    result.isLeft should be(true)
+    result.left.value shouldBe a[NonOverwriteFileExistsError]
+  }
+
+  it should "return FileCreateError (not NonOverwriteFileExistsError) when ObjectWithETag and 412 — fencing must stay fatal" in {
+    when(client.create(any[BlobInfo], any[Array[Byte]], any[BlobTargetOption]))
+      .thenThrow(new StorageException(412, "Precondition Failed"))
+
+    val result =
+      storageInterface.writeBlobToFile("bucket", "path", ObjectWithETag(TestIndexFile("o", Some(1L)), "123"))
+
+    result.isLeft should be(true)
+    result.left.value shouldBe a[FileCreateError]
+  }
+
+  it should "return FileCreateError when NoOverwriteExistingObject fails with a non-412 error" in {
+    when(client.create(any[BlobInfo], any[Array[Byte]], any[BlobTargetOption]))
+      .thenThrow(new StorageException(500, "Internal Error"))
+
+    val result =
+      storageInterface.writeBlobToFile("bucket", "path", NoOverwriteExistingObject(TestIndexFile("o", Some(1L))))
+
+    result.isLeft should be(true)
+    result.left.value shouldBe a[FileCreateError]
   }
 
 }


### PR DESCRIPTION
## Problem

At cold start with high `tasks.max`, multiple tasks open the same topic-partition concurrently. No master lock exists yet, so each task takes the `FileNotFoundError` branch and calls `createNewIndexFileNoOverwrite`. One task wins the NoOverwrite create; the losers fail because the destination now exists. Previously that became a `FatalCloudSinkError` → `FatalConnectException` and the losing task **died** — recoverable only by a manual restart (~22% of tasks at first boot on ADLS).

Observed trace:
```
FatalConnectException: error writing file ({"owner":"<uuid>","committedOffset":null,"pendingState":null})
Status code 409, PathAlreadyExists
at CloudSinkTask.open(...)
```

**Root cause.** The storage layer reported the lost race as a generic `FileCreateError` that the index manager treated as fatal. On Azure the rename surfaces the collision as **409 PathAlreadyExists** (not the assumed 412), which fell straight through to the fatal arm. S3/GCS had the same latent race.

## Fix (two layers)

- **Layer A — per-cloud storage.** `writeBlobToFile` returns a new recoverable `NonOverwriteFileExistsError` when a `NoOverwriteExistingObject` create loses the race (Azure 409/412, S3 `PreconditionFailed`, GCS 412). Scoped to NoOverwrite only — an `ObjectWithETag` eTag mismatch stays a fatal `FileCreateError`, so **zombie fencing is unchanged**.
- **Layer B — shared `IndexManagerV2`.** On that signal, `decideOpen` re-reads the now-existing lock and routes it through the **same** match arms, so a lock carrying a `PendingState` flows through `processPendingOperations` (correct crash recovery) instead of a naive eTag adoption — the bug that got the earlier attempt reverted (`eef9b3269`). Bounded to `MaxOpenCreateRaceAttempts` (3); exhaustion surfaces a fatal error (no worse than today).

The granular-lock path (`ensureGranularLock`) already had an equivalent re-read fallback and is unaffected.

## Invariants (no data loss / no duplication / no zombie regression)

The fix maps the lost-race loser onto the already-safe "two tasks share one lock at the same eTag" state. Single-committer fencing is enforced solely at commit time by `setIfMatch(eTag)` and is untouched; the eTag fence precedes the durable Copy-to-final-object, so a fenced loser cannot duplicate data. The loser adopts the winner's **durable** committed offset (dedup floor) and resolves any `PendingState` before caching.

## Tests

- Per-cloud storage: NoOverwrite + 409/412 → `NonOverwriteFileExistsError`; `ObjectWithETag` + 412/409 → still `FileCreateError`; non-precondition error → still `FileCreateError`.
- `IndexManagerV2`: lost-race → clean re-read adopts offset + eTag; lost-race → PendingState re-read invokes `processPendingOperations`; bounded-retry exhaustion → `FatalCloudSinkError` after exactly 3 reads.

All four module suites pass (cloud-common 708, aws-s3 107, azure-datalake 85, gcp-storage 96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)