### PR TITLE
test(cloud-sink): fix interrupt-flag leak flaking IndexManagerV2Test

### DIFF
--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/seek/IndexManagerV2Test.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/sink/seek/IndexManagerV2Test.scala
@@ -73,6 +73,12 @@ class IndexManagerV2Test
   private var indexManagerV2: IndexManagerV2 = _
 
   before {
+    // Defensive: a prior test (e.g. "drainGcQueue catches InterruptedException ...") can leave
+    // the current thread's interrupt flag set — close()'s final drainGcQueue / awaitTermination
+    // re-raises it after the test's own clear. cats-effect's unsafeRunSync() in open() returns
+    // None on an interrupted thread, which surfaces as NoSuchElementException: None.get. Clear any
+    // leaked interrupt state before each test so the flake cannot propagate between tests.
+    val _ = Thread.interrupted()
     reset(storageInterface, connectorTaskId, bucketAndPrefixFn, pendingOperationsProcessors)
 
     indexManagerV2 = new IndexManagerV2(
@@ -2287,11 +2293,11 @@ class IndexManagerV2Test
     val si              = mock[StorageInterface[_]]
     setupSweepMocks(si, tp, bucketAndPrefix)
 
-    val pk        = "name=report.lock.tmp.archive"
-    val oldTime   = Instant.now().minusSeconds(7200)
-    val realLock  = s"$indexesDirectoryName/${connectorTaskId.name}/.locks/${tp.topic}/${tp.partition}/$pk.lock"
-    val realMeta  = TestFileMetadata(realLock, oldTime)
-    val listResp  = ListOfMetadataResponse("bucket", Some("prefix"), Seq(realMeta), realMeta)
+    val pk       = "name=report.lock.tmp.archive"
+    val oldTime  = Instant.now().minusSeconds(7200)
+    val realLock = s"$indexesDirectoryName/${connectorTaskId.name}/.locks/${tp.topic}/${tp.partition}/$pk.lock"
+    val realMeta = TestFileMetadata(realLock, oldTime)
+    val listResp = ListOfMetadataResponse("bucket", Some("prefix"), Seq(realMeta), realMeta)
 
     org.mockito.Mockito.doReturn(Right(Some(listResp))).when(si).listFileMetaRecursive(anyString(), any[Option[String]])
     // Real lock content with committedOffset >= masterOffset (100), so the normal
@@ -4294,8 +4300,12 @@ class IndexManagerV2Test
       // Polled item was re-enqueued, not silently dropped.
       im.gcQueueSize shouldBe 1
     } finally {
-      Thread.interrupted() // clean up interrupt flag for subsequent tests
+      // Order matters: close() runs a final drainGcQueue() (with deleteFiles still stubbed to
+      // throw InterruptedException) and awaitTermination(), both of which RESTORE the interrupt
+      // flag. Clearing it must therefore happen AFTER close(), or the flag leaks into the next
+      // test and breaks its unsafeRunSync(). The defensive clear in `before` is the backstop.
       im.close()
+      val _ = Thread.interrupted() // clean up interrupt flag for subsequent tests
     }
   }
 


### PR DESCRIPTION
## Problem

`IndexManagerV2Test > cleanUpObsoleteLocks returns Left when bucketAndPrefixFn fails for non-empty keysToRemove` failed intermittently in the full `cloud-common` suite (but passed when the suite was run on its own):

```
java.util.NoSuchElementException: None.get
  at cats.effect.IOPlatform.unsafeRunSync
  at IndexManagerV2.open(IndexManagerV2.scala:265)
  at IndexManagerV2Test.<the failing test>(im.open(Set(tp)))
```

## Root cause

The **preceding** test — `drainGcQueue catches InterruptedException, re-enqueues unprocessed items, and restores the interrupt flag` — deliberately sets the thread's interrupt flag. Its `finally` cleared the flag and *then* called `im.close()`:

```scala
} finally {
  Thread.interrupted()  // clears the flag
  im.close()            // ...then re-raises it
}
```

`close()` restores the interrupt flag in two places: the `awaitTermination()` `InterruptedException` catch (re-interrupts), and the final `drainGcQueue()` — which still hits the `si.deleteFiles` stub throwing `InterruptedException` and restores the flag. So the flag was cleared too early and **leaked into the next test**. On an interrupted thread, cats-effect's `unsafeRunSync()` (used by `IndexManagerV2.open`) returns `None`, which surfaces as `NoSuchElementException: None.get`. It only manifested under full-suite load, hence the flakiness.

## Fix

- **Reorder** the interrupt test's cleanup to clear the flag **after** `im.close()`, so the restore-on-close no longer leaks.
- **Defensive backstop**: clear any leaked interrupt flag at the start of the `before` hook, so no test can ever inherit an interrupted thread regardless of which test set it.

No production code change — this is purely test stability.

## Verification

Full `cloud-common/test` now passes **842/842** across 3 consecutive runs (previously 841 passed / 1 failed intermittently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)