### PR TITLE
feat(cloud-source): restore original topic from envelope metadata

### DIFF
--- a/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceJsonEnvelopeTopicFromMetadataTest.scala
+++ b/kafka-connect-aws-s3/src/it/scala/io/lenses/streamreactor/connect/aws/s3/source/S3SourceJsonEnvelopeTopicFromMetadataTest.scala
@@ -1,0 +1,75 @@
+package io.lenses.streamreactor.connect.aws.s3.source
+
+import cats.implicits.toBifunctorOps
+import io.lenses.streamreactor.connect.aws.s3.utils.S3ProxyContainerTest
+import io.lenses.streamreactor.connect.cloud.common.model.UploadableFile
+import io.lenses.streamreactor.connect.cloud.common.source.config.CloudSourceSettingsKeys
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import java.io.BufferedWriter
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+class S3SourceJsonEnvelopeTopicFromMetadataTest
+    extends S3ProxyContainerTest
+    with AnyFlatSpecLike
+    with Matchers
+    with EitherValues
+    with CloudSourceSettingsKeys
+    with TempFileHelper {
+
+  private val MyPrefix = "backups"
+  private val TopicA   = "com.olx.posting.olxro.Ad"
+  private val TopicB   = "com.olx.posting.olxpl.Ad"
+
+  // Two envelopes pointing at two different original topics, stored in one backup file.
+  private val EnvelopeTopicA: String =
+    s"""{"key":{"id":"1"},"value":{"id":"1"},"headers":{"h":"v"},"metadata":{"timestamp":1234567890,"topic":"$TopicA","partition":0,"offset":0}}"""
+  private val EnvelopeTopicB: String =
+    s"""{"key":{"id":"2"},"value":{"id":"2"},"headers":{"h":"v"},"metadata":{"timestamp":1234567891,"topic":"$TopicB","partition":1,"offset":0}}"""
+
+  "task" should "restore each record to the original topic from the envelope metadata" in {
+    val existing = listBucketPath(BucketName, s"$MyPrefix/json/")
+    if (existing.nonEmpty) storageInterface.deleteFiles(BucketName, existing)
+    uploadFile()
+
+    val task = new S3SourceTask()
+
+    val props = (defaultProps ++ Map(
+      "connect.s3.kcql" -> s"insert into placeholder select * from $BucketName:$MyPrefix/json STOREAS `JSON` LIMIT 1000 PROPERTIES ('store.envelope'=true, 'source.topic.from.envelope'=true)",
+      "connect.s3.source.partition.search.recurse.levels"     -> "0",
+      "connect.s3.source.partition.search.continuous"         -> "false",
+      SOURCE_PARTITION_SEARCH_INTERVAL_MILLIS                  -> "1000",
+    )).asJava
+
+    task.start(props)
+
+    try {
+      val sourceRecords = SourceRecordsLoop.loop(task, 10.seconds.toMillis, 2).value
+      task.poll() should be(empty)
+
+      val byTopic = sourceRecords.map(r => r.topic() -> r).toMap
+      byTopic.keySet shouldBe Set(TopicA, TopicB)
+      byTopic(TopicA).kafkaPartition() shouldBe 0
+      byTopic(TopicB).kafkaPartition() shouldBe 1
+    } finally {
+      task.stop()
+    }
+  }
+
+  private def uploadFile() =
+    withFile("00001.json") { file =>
+      val bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file)))
+      bw.write(EnvelopeTopicA)
+      bw.newLine()
+      bw.write(EnvelopeTopicB)
+      bw.flush()
+      bw.close()
+      storageInterface.uploadFile(UploadableFile(file), BucketName, s"$MyPrefix/json/0")
+        .leftMap(e => new UploadException(e))
+    }
+}

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/config/S3SourceConfigTest.scala
@@ -65,5 +65,47 @@ class S3SourceConfigTest extends AnyFunSuite with Matchers with TaskIndexKey wit
 
   }
 
+  test("enables source.topic.from.envelope when the envelope is stored") {
+    val props = DefaultProps ++ Map(
+      "connect.s3.kcql" ->
+        s"""insert into placeholder select * from $BucketName:prefix STOREAS `JSON` LIMIT 1000 PROPERTIES ( 'store.envelope' = 'true', 'source.topic.from.envelope' = 'true' )""",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+    )
+
+    S3SourceConfig(S3SourceConfigDefBuilder(props)) match {
+      case Left(value) => fail(value.toString)
+      case Right(config) =>
+        config.bucketOptions.size shouldBe 1
+        config.bucketOptions.head.hasEnvelope shouldBe true
+        config.bucketOptions.head.topicFromEnvelope shouldBe true
+    }
+  }
+
+  test("source.topic.from.envelope defaults to false") {
+    val props = DefaultProps ++ Map(
+      "connect.s3.kcql" ->
+        s"""insert into topic1 select * from $BucketName:prefix STOREAS `JSON` LIMIT 1000 PROPERTIES ( 'store.envelope' = 'true' )""",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+    )
+
+    S3SourceConfig(S3SourceConfigDefBuilder(props)) match {
+      case Left(value)   => fail(value.toString)
+      case Right(config) => config.bucketOptions.head.topicFromEnvelope shouldBe false
+    }
+  }
+
+  test("source.topic.from.envelope without store.envelope is rejected") {
+    val props = DefaultProps ++ Map(
+      "connect.s3.kcql" ->
+        s"""insert into placeholder select * from $BucketName:prefix STOREAS `JSON` LIMIT 1000 PROPERTIES ( 'source.topic.from.envelope' = 'true' )""",
+      "connect.s3.source.partition.search.recurse.levels" -> "0",
+    )
+
+    S3SourceConfig(S3SourceConfigDefBuilder(props)) match {
+      case Left(value) => value.getMessage should include("source.topic.from.envelope")
+      case Right(_)    => fail("Expected validation to fail when store.envelope is not enabled")
+    }
+  }
+
   override def connectorPrefix: String = CONNECTOR_PREFIX
 }

--- a/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/state/ReaderManagerBuilderTest.scala
+++ b/kafka-connect-aws-s3/src/test/scala/io/lenses/streamreactor/connect/aws/s3/source/state/ReaderManagerBuilderTest.scala
@@ -64,6 +64,7 @@ class ReaderManagerBuilderTest extends AsyncFlatSpec with AsyncIOSpec with Match
                                                        None,
                                                        OrderingType.LastModified,
                                                        false,
+                                                       false,
                                                        Option.empty,
                                                        false,
     )
@@ -110,6 +111,7 @@ class ReaderManagerBuilderTest extends AsyncFlatSpec with AsyncIOSpec with Match
                                                        100,
                                                        None,
                                                        OrderingType.LastModified,
+                                                       false,
                                                        false,
                                                        Option.empty,
                                                        false,

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/FormatSelection.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/FormatSelection.scala
@@ -59,6 +59,7 @@ case class ReaderBuilderContext(
   targetPartition:         Integer,
   targetTopic:             Topic,
   watermarkPartition:      java.util.Map[String, String],
+  topicFromEnvelope:       Boolean = false,
 )
 
 sealed trait FormatSelection {
@@ -131,6 +132,7 @@ case object JsonFormatSelection extends FormatSelection {
                                         input.targetPartition,
                                         input.bucketAndPath,
                                         input.metadata.lastModified,
+                                        topicFromEnvelope = input.topicFromEnvelope,
         )
 
       } else {
@@ -167,6 +169,7 @@ case object AvroFormatSelection extends FormatSelection {
                                             input.targetPartition,
                                             input.bucketAndPath,
                                             input.metadata.lastModified,
+                                            topicFromEnvelope = input.topicFromEnvelope,
         )
       } else {
         new SchemaAndValueConverter(
@@ -209,6 +212,7 @@ case object ParquetFormatSelection extends FormatSelection {
                                             input.targetPartition,
                                             input.bucketAndPath,
                                             input.metadata.lastModified,
+                                            topicFromEnvelope = input.topicFromEnvelope,
         )
       } else {
         new SchemaAndValueConverter(

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/kcqlprops/PropsKeyEnum.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/config/kcqlprops/PropsKeyEnum.scala
@@ -49,6 +49,8 @@ object PropsKeyEnum extends Enum[PropsKeyEntry] {
   case object StoreFileNamer        extends PropsKeyEntry(DataStorageSettings.StoreFileNamer)
   case object StoreFileNamerParam   extends PropsKeyEntry(DataStorageSettings.StoreFileNamerParam)
 
+  case object SourceTopicFromEnvelope extends PropsKeyEntry("source.topic.from.envelope")
+
   case object PaddingLength extends PropsKeyEntry("padding.length")
 
   case object PaddingCharacter extends PropsKeyEntry("padding.char")

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemaAndValueEnvelopeConverter.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemaAndValueEnvelopeConverter.scala
@@ -59,6 +59,8 @@ import scala.jdk.CollectionConverters.ListHasAsScala
  * @param partition The target partition; only used if the envelope does not contain a partition
  * @param location The cloud location of the object
  * @param lastModified The last modified date of the object
+ * @param topicFromEnvelope When true, the record is emitted to the original topic stored in the
+ *                          envelope metadata, falling back to `topic` when it is not present
  */
 class SchemaAndValueEnvelopeConverter(
   watermarkPartition: java.util.Map[String, String],
@@ -67,6 +69,7 @@ class SchemaAndValueEnvelopeConverter(
   location:           CloudLocation,
   lastModified:       Instant,
   instantF:           () => Instant = () => Instant.now(),
+  topicFromEnvelope:  Boolean       = false,
 ) extends Converter[SchemaAndValue] {
   override def convert(schemaAndValue: SchemaAndValue, index: Long, lastLine: Boolean): SourceRecord = {
     if (schemaAndValue.schema().`type`() != Schema.Type.STRUCT) {
@@ -101,10 +104,16 @@ class SchemaAndValueEnvelopeConverter(
         struct.get("metadata").asInstanceOf[org.apache.kafka.connect.data.Struct].getInt64("timestamp")
       } else instantF().toEpochMilli
 
+    val recordTopic: String =
+      if (topicFromEnvelope && fields.contains("metadata")) {
+        val meta = struct.get("metadata").asInstanceOf[org.apache.kafka.connect.data.Struct]
+        Option(meta.schema().field("topic")).flatMap(_ => Option(meta.getString("topic"))).getOrElse(topic.value)
+      } else topic.value
+
     new SourceRecord(
       watermarkPartition,
       SourceWatermark.offset(location, index, lastModified, lastLine),
-      topic.value,
+      recordTopic,
       partition,
       keySchema.orNull,
       key.orNull,

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemalessEnvelopeConverter.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemalessEnvelopeConverter.scala
@@ -58,6 +58,8 @@ import scala.annotation.nowarn
  * @param partition The target partition; only used if the envelope does not contain a partition
  * @param location The cloud location of the object
  * @param lastModified The last modified date of the object
+ * @param topicFromEnvelope When true, the record is emitted to the original topic stored in the
+ *                          envelope metadata, falling back to `topic` when it is not present
  */
 class SchemalessEnvelopeConverter(
   watermarkPartition: java.util.Map[String, String],
@@ -66,6 +68,7 @@ class SchemalessEnvelopeConverter(
   location:           CloudLocation,
   lastModified:       Instant,
   instantF:           () => Instant = () => Instant.now(),
+  topicFromEnvelope:  Boolean       = false,
 ) extends Converter[String] {
   override def convert(envelope: String, index: Long, lastLine: Boolean): SourceRecord =
     //parse the json and then extract key,value, headers and metadata
@@ -84,10 +87,15 @@ class SchemalessEnvelopeConverter(
           _.asObject.getOrElse(throw new RuntimeException(s"Envelope [$envelope] does not contain metadata.")),
         )
 
+        val recordTopic =
+          if (topicFromEnvelope)
+            metadata.flatMap(j => j("topic")).flatMap(_.asString).getOrElse(topic.value)
+          else topic.value
+
         val sourceRecord = new SourceRecord(
           watermarkPartition,
           SourceWatermark.offset(location, index, lastModified, lastLine),
-          topic.value,
+          recordTopic,
           metadata.flatMap(j => j("partition").get.asNumber.flatMap(_.toInt).map(Integer.valueOf)).getOrElse(partition),
           key.map { _ =>
             if (!keyIsArray) Schema.OPTIONAL_STRING_SCHEMA

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/config/CloudSourceBucketOptions.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/config/CloudSourceBucketOptions.scala
@@ -18,11 +18,13 @@ package io.lenses.streamreactor.connect.cloud.common.source.config
 import cats.implicits.toTraverseOps
 import io.lenses.kcql.Kcql
 import io.lenses.streamreactor.connect.cloud.common.config.FormatSelection
+import io.lenses.streamreactor.connect.cloud.common.config.kcqlprops.PropsKeyEnum
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocation
 import io.lenses.streamreactor.connect.cloud.common.model.location.CloudLocationValidator
 import io.lenses.streamreactor.connect.cloud.common.source.config.kcqlprops.CloudSourceProps
 import io.lenses.streamreactor.connect.cloud.common.source.config.kcqlprops.CloudSourcePropsSchema
 import io.lenses.streamreactor.connect.cloud.common.storage.FileListError
+import org.apache.kafka.common.config.ConfigException
 import io.lenses.streamreactor.connect.cloud.common.storage.FileMetadata
 import io.lenses.streamreactor.connect.cloud.common.storage.ListOfKeysResponse
 import io.lenses.streamreactor.connect.cloud.common.storage.StorageInterface
@@ -48,6 +50,16 @@ object CloudSourceBucketOptions {
           //extract the envelope. of not present default to false
           hasEnvelope <- config.extractEnvelope(sourceProps)
 
+          // when true, restore each record to the original topic stored in the envelope metadata
+          topicFromEnvelope <- sourceProps.getBooleanOrDefault(PropsKeyEnum.SourceTopicFromEnvelope, false)
+          _ <- Either.cond(
+            !topicFromEnvelope || hasEnvelope.getOrElse(false),
+            (),
+            new ConfigException(
+              s"`${PropsKeyEnum.SourceTopicFromEnvelope.entryName}` requires `${PropsKeyEnum.StoreEnvelope.entryName}` to be set to true.",
+            ),
+          )
+
           postProcessAction <- PostProcessAction(source.prefix, sourceProps)
 
           // Late arrival processing only applies when Move post-process action is configured with processLateArrival=true
@@ -65,6 +77,7 @@ object CloudSourceBucketOptions {
           partitionExtractor = partitionExtractor,
           orderingType       = config.extractOrderingType,
           hasEnvelope        = hasEnvelope.getOrElse(false),
+          topicFromEnvelope  = topicFromEnvelope,
           postProcessAction  = postProcessAction,
           processLateArrival = processLateArrival,
         )
@@ -81,6 +94,7 @@ case class CloudSourceBucketOptions[M <: FileMetadata](
   partitionExtractor:    Option[PartitionExtractor],
   orderingType:          OrderingType,
   hasEnvelope:           Boolean,
+  topicFromEnvelope:     Boolean,
   postProcessAction:     Option[PostProcessAction],
   processLateArrival:    Boolean,
 ) {

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/config/kcqlprops/CloudSourcePropsSchema.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/config/kcqlprops/CloudSourcePropsSchema.scala
@@ -36,6 +36,7 @@ object CloudSourcePropsSchema {
     BufferSize                                   -> IntPropsSchema,
     ReadTrimLine                                 -> BooleanPropsSchema,
     StoreEnvelope                                -> BooleanPropsSchema,
+    SourceTopicFromEnvelope                      -> BooleanPropsSchema,
     PostProcessAction                            -> EnumPropsSchema(PostProcessActionEnum),
     PostProcessActionBucket                      -> StringPropsSchema,
     PostProcessActionPrefix                      -> StringPropsSchema,

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/reader/ResultReader.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/reader/ResultReader.scala
@@ -79,6 +79,7 @@ object ResultReader extends LazyLogging {
     connectorTaskId:         ConnectorTaskId,
     storageInterface:        StorageInterface[SM],
     hasEnvelope:             Boolean,
+    topicFromEnvelope:       Boolean,
   ): CloudLocation => Either[Throwable, ResultReader] = { pathWithLine =>
     for {
       path   <- pathWithLine.path.toRight(new IllegalStateException("No path found"))
@@ -112,6 +113,7 @@ object ResultReader extends LazyLogging {
                 partition,
                 Topic(targetTopic),
                 SourceWatermark.partition(pathWithLine),
+                topicFromEnvelope,
               ),
             )
             _ <- pathWithLine.line match {

--- a/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/state/ReaderManagerBuilder.scala
+++ b/kafka-connect-cloud-common/src/main/scala/io/lenses/streamreactor/connect/cloud/common/source/state/ReaderManagerBuilder.scala
@@ -97,6 +97,7 @@ object ReaderManagerBuilder extends LazyLogging {
         connectorTaskId,
         storageInterface,
         sbo.hasEnvelope,
+        sbo.topicFromEnvelope,
       ),
       connectorTaskId,
       ref,

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemaAndValueEnvelopeConverterTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemaAndValueEnvelopeConverterTest.scala
@@ -228,13 +228,71 @@ class SchemaAndValueEnvelopeConverterTest extends AnyFunSuite with Matchers {
       createConverter().convert(schemaAndValueEnveloper, 0L, lastLine = true)
     }
   }
-  private def createConverter(instantF: () => Instant = () => Instant.now()): SchemaAndValueEnvelopeConverter =
+  test("topicFromEnvelope uses the topic stored in the envelope metadata") {
+    val envelopeSchema = SchemaBuilder.struct()
+      .field("key", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("metadata", MetadataSchema)
+      .build()
+    val envelope = new Struct(envelopeSchema)
+    envelope.put("key", "key")
+    envelope.put("value", "value")
+    envelope.put("metadata", createMetadata())
+
+    val sourceRecord = createConverter(topicFromEnvelope = true)
+      .convert(new SchemaAndValue(envelopeSchema, envelope), 0L, lastLine = true)
+    sourceRecord.topic() shouldBe SourceTopic
+    sourceRecord.kafkaPartition() shouldBe Partition
+  }
+
+  test("topicFromEnvelope falls back to the target topic when metadata is missing") {
+    val envelopeSchema = SchemaBuilder.struct()
+      .field("key", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+      .build()
+    val envelope = new Struct(envelopeSchema)
+    envelope.put("key", "key")
+    envelope.put("value", "value")
+
+    val sourceRecord = createConverter(() => LastModifiedTimestamp, topicFromEnvelope = true)
+      .convert(new SchemaAndValue(envelopeSchema, envelope), 0L, lastLine = true)
+    sourceRecord.topic() shouldBe TargetTopic
+  }
+
+  test("topicFromEnvelope falls back to the target topic when metadata has no topic field") {
+    val metadataSchema = SchemaBuilder.struct()
+      .field("timestamp", Schema.INT64_SCHEMA)
+      .field("partition", Schema.INT32_SCHEMA)
+      .build()
+    val envelopeSchema = SchemaBuilder.struct()
+      .field("key", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("metadata", metadataSchema)
+      .build()
+    val metadata = new Struct(metadataSchema)
+    metadata.put("timestamp", Timestamp)
+    metadata.put("partition", Partition)
+    val envelope = new Struct(envelopeSchema)
+    envelope.put("key", "key")
+    envelope.put("value", "value")
+    envelope.put("metadata", metadata)
+
+    val sourceRecord = createConverter(topicFromEnvelope = true)
+      .convert(new SchemaAndValue(envelopeSchema, envelope), 0L, lastLine = true)
+    sourceRecord.topic() shouldBe TargetTopic
+  }
+
+  private def createConverter(
+    instantF:          () => Instant = () => Instant.now(),
+    topicFromEnvelope: Boolean       = false,
+  ): SchemaAndValueEnvelopeConverter =
     new SchemaAndValueEnvelopeConverter(Map("partition" -> "abc").asJava,
                                         Topic(TargetTopic),
                                         TargetPartition,
                                         cloudLocation,
                                         LastModifiedTimestamp,
                                         instantF,
+                                        topicFromEnvelope,
     )
   private def assertOffsets(sourceRecord: SourceRecord): Assertion = {
     sourceRecord.sourcePartition().asScala shouldBe Map("partition" -> "abc")

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemalessEnvelopeConverterTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/formats/reader/converters/SchemalessEnvelopeConverterTest.scala
@@ -202,13 +202,53 @@ class SchemalessEnvelopeConverterTest extends AnyFunSuite with Matchers {
     actual.value() shouldBe "value".getBytes()
     assertHeaders(actual)
   }
-  private def createConverter(instantF: () => Instant = () => Instant.now()): SchemalessEnvelopeConverter =
+  test("topicFromEnvelope uses the topic stored in the envelope metadata") {
+    val json = Json.obj(
+      "key"      -> Json.fromString("key"),
+      "value"    -> Json.fromString("value"),
+      "metadata" -> createMetadata(),
+    )
+
+    val actual = createConverter(topicFromEnvelope = true).convert(json.noSpaces, 0, lastLine = false)
+    actual.topic() shouldBe SourceTopic
+    actual.kafkaPartition() shouldBe Partition
+  }
+
+  test("topicFromEnvelope falls back to the target topic when metadata is missing") {
+    val json = Json.obj(
+      "key"   -> Json.fromString("key"),
+      "value" -> Json.fromString("value"),
+    )
+
+    val actual = createConverter(topicFromEnvelope = true).convert(json.noSpaces, 0, lastLine = false)
+    actual.topic() shouldBe TargetTopic
+  }
+
+  test("topicFromEnvelope falls back to the target topic when metadata has no topic") {
+    val json = Json.obj(
+      "key"   -> Json.fromString("key"),
+      "value" -> Json.fromString("value"),
+      "metadata" -> Json.obj(
+        "timestamp" -> Json.fromLong(Timestamp),
+        "partition" -> Json.fromInt(Partition),
+      ),
+    )
+
+    val actual = createConverter(topicFromEnvelope = true).convert(json.noSpaces, 0, lastLine = false)
+    actual.topic() shouldBe TargetTopic
+  }
+
+  private def createConverter(
+    instantF:          () => Instant = () => Instant.now(),
+    topicFromEnvelope: Boolean       = false,
+  ): SchemalessEnvelopeConverter =
     new SchemalessEnvelopeConverter(Map("partition" -> "abc").asJava,
                                     Topic(TargetTopic),
                                     TargetPartition,
                                     location,
                                     LastModifiedTimestamp,
                                     instantF,
+                                    topicFromEnvelope,
     )
 
   private def assertOffsets(sourceRecord: SourceRecord): Assertion = {

--- a/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/source/LateArrivalTouchTaskTest.scala
+++ b/kafka-connect-cloud-common/src/test/scala/io/lenses/streamreactor/connect/cloud/common/source/LateArrivalTouchTaskTest.scala
@@ -272,6 +272,7 @@ class LateArrivalTouchTaskTest extends AnyFlatSpec with Matchers with MockitoSug
       partitionExtractor    = None,
       orderingType          = mock[io.lenses.streamreactor.connect.cloud.common.source.config.OrderingType],
       hasEnvelope           = false,
+      topicFromEnvelope     = false,
       postProcessAction     = None,
       processLateArrival    = processLateArrival,
     )


### PR DESCRIPTION
## Problem

The cloud **source** connectors map exactly one target topic per KCQL `INSERT INTO` clause. Restoring an S3/GCS/Azure backup that spans many topics (e.g. hundreds) therefore requires one KCQL statement — or one connector — per topic, which has to be regenerated whenever topics are added.

The envelope written by the sink (`STOREAS ... PROPERTIES('store.envelope'=true)`) already records the original topic in `metadata.topic`, and the source already restores partition, key, headers and timestamp from it — only the topic is ignored.

## Change

Adds an opt-in per-KCQL boolean property **`source.topic.from.envelope`** (default `false`). When enabled together with `store.envelope`, each record is restored to the original topic from the envelope metadata, falling back to the `INSERT INTO` target when the envelope has no topic. Validation requires `store.envelope=true`.

This lets a single connector with one KCQL statement restore all topics at once:

```sql
INSERT INTO `placeholder`
SELECT * FROM `my-backup-bucket`
STOREAS `JSON`
PROPERTIES('store.envelope'=true, 'source.topic.from.envelope'=true)
```

The flag is plumbed from `CloudSourceBucketOptions` through `ResultReader` and `FormatSelection` into the JSON (`SchemalessEnvelopeConverter`) and Avro/Parquet (`SchemaAndValueEnvelopeConverter`) envelope converters. It lives in `cloud-common`, so it applies to the **AWS S3, GCP Storage and Azure Datalake** source connectors.

## Behaviour notes

- Partition, key, headers and timestamp continue to be restored from the envelope (unchanged).
- Original Kafka offsets are not preserved (the source watermark is object/line based) — same as before.
- Default behaviour is unchanged when the property is absent or `false`.

## Tests

- Unit tests for both envelope converters: topic taken from metadata; fallback when metadata/topic absent.
- Config tests: property parsing, default `false`, and validation rejecting the flag without `store.envelope`.
- New integration test (`S3SourceJsonEnvelopeTopicFromMetadataTest`) restoring two records carrying different `metadata.topic` values to their respective topics.
- Full `compile` + `Test/compile` across all modules; scalafmt and header checks pass.