### PR TITLE
feat(kafka-connect-mqtt): add service loader manifests

### DIFF
--- a/kafka-connect-mqtt/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/kafka-connect-mqtt/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,1 @@
+io.lenses.streamreactor.connect.mqtt.sink.MqttSinkConnector

--- a/kafka-connect-mqtt/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/kafka-connect-mqtt/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,1 @@
+io.lenses.streamreactor.connect.mqtt.source.MqttSourceConnector


### PR DESCRIPTION
This allows the MQTT connectors to work when using "plugin.discovery=service_load".

See https://kafka.apache.org/43/kafka-connect/user-guide/#developers-source-migration